### PR TITLE
Remove contract base64 as they are now used as binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,12 +368,12 @@ const opIds = await web3Client.smartContracts().deploySmartContract(
         fee: 0,
         maxGas: 2000000,
         coins: 0,
-        contractDataBase64: compiledScFromSource.base64,
+        contractDataBinary: compiledScFromSource.binary,
     } as IContractData,
     baseAccount
 );
 ```
-The compiledScFromSource is the base64 compiled smart contract code that could easily be obtained using massa's https://www.npmjs.com/package/massa-sc-utils
+The compiledScFromSource is the compiled smart contract code in binary form.
 
 ### Smart contract event fetching and polling
 
@@ -530,7 +530,7 @@ const data: Array<IExecuteReadOnlyResponse> = await web3Client.smartContracts().
         fee: 0,
         maxGas: 2000000,
         coins: 0,
-        contractDataBase64: compiledScFromSource.base64,
+        contractDataBinary: compiledScFromSource.binary,
     } as IContractData,
     baseAccount
 );

--- a/examples/smartContracts/deployer.ts
+++ b/examples/smartContracts/deployer.ts
@@ -42,7 +42,7 @@ export const deploySmartContract = async (
 			console.error(msg);
 			throw new Error(ex);
 		}
-		if (!compiledSc.base64) {
+		if (!compiledSc.binary) {
 			const msg = chalk.red(`No bytecode to deploy for wasm file ${chalk.yellow(deploymentScWasm)}. Check AS compiler`);
 			console.error(msg);
 			throw new Error(msg);
@@ -59,16 +59,16 @@ export const deploySmartContract = async (
 			console.error(msg);
 			throw new Error(ex);
 		}
-		if (!compiledDeployedSc.base64) {
+		if (!compiledDeployedSc.binary) {
 			const msg = chalk.red(`No bytecode to deploy for wasm file ${chalk.yellow(deployedScWasm)}. Check AS compiler`);
 			console.error(msg);
 			throw new Error(msg);
 		}
 
-		contractData.contractDataBase64 = compiledSc.base64;
 		contractData.contractDataBinary = compiledSc.binary;
 		contractData.contractDataText = compiledSc.text;
 		const key1: Uint8Array = Uint8Array.from([0, 1, 2, 3, 4]);
+		contractData.datastore = new Map<Uint8Array, Uint8Array>();
 		contractData.datastore.set(key1, compiledDeployedSc.binary);
 
 		// deploy smart contract

--- a/src/interfaces/IContractData.ts
+++ b/src/interfaces/IContractData.ts
@@ -3,11 +3,9 @@ export interface IContractData {
 	fee: number;
 	/// The maximum amount of gas that the execution of the contract is allowed to cost.
 	maxGas: number;
-	/// Smart contract data as bytecode.
-	contractDataBase64?: string;
 	/// Smart contract data as text.
 	contractDataText?: string;
-	/// Smart contract data as base64-encoded.
+	/// Smart contract data as bytecode
 	contractDataBinary?: Uint8Array;
 	/// smart contract address
 	address?: string;

--- a/src/web3/BaseClient.ts
+++ b/src/web3/BaseClient.ts
@@ -161,14 +161,14 @@ export class BaseClient {
 		switch (opTypeId) {
 			case OperationTypeId.ExecuteSC: {
 
-				// revert base64 sc data to binary
-				const decodedScBinaryCode = new Uint8Array(Buffer.from((data as IContractData).contractDataBase64, "base64"));
+				// get sc data binary
+				const scBinaryCode = (data as IContractData).contractDataBinary;
 
 				// max gas
 				const maxGasEncoded = Buffer.from(varintEncode((data as IContractData).maxGas));
 
 				// contract data
-				const contractDataEncoded = Buffer.from(decodedScBinaryCode);
+				const contractDataEncoded = Buffer.from(scBinaryCode);
 				const dataLengthEncoded = Buffer.from(varintEncode(contractDataEncoded.length));
 
 				// smart contract operation datastore

--- a/src/web3/SmartContractsClient.ts
+++ b/src/web3/SmartContractsClient.ts
@@ -50,7 +50,7 @@ export class SmartContractsClient extends BaseClient implements ISmartContractsC
 		const expiryPeriod: number = nodeStatusInfo.next_slot.period + this.clientConfig.periodOffset;
 
 		// get the block size
-		if (contractData.contractDataBase64.length > nodeStatusInfo.config.max_block_size / 2) {
+		if (contractData.contractDataBinary.length > nodeStatusInfo.config.max_block_size / 2) {
 			console.warn("bytecode size exceeded half of the maximum size of a block, operation will certainly be rejected");
 		}
 
@@ -66,9 +66,9 @@ export class SmartContractsClient extends BaseClient implements ISmartContractsC
 		// sign payload
 		const signature: ISignature = await WalletClient.walletSignMessage(Buffer.concat([WalletClient.getBytesPublicKey(sender.publicKey), bytesCompact]), sender);
 
-		// revert base64 sc data to binary
-		if (!contractData.contractDataBase64) {
-			throw new Error(`Contract base64 encoded data required. Got null`);
+		// Check if SC data exists
+		if (!contractData.contractDataBinary) {
+			throw new Error(`Contract data required. Got null`);
 		}
 
 		const data = {


### PR DESCRIPTION
Base64 contract has been removed from everywhere and should be used as bytes.