### PR TITLE
269 test walletGenerateNewAccount & getAccountFromSecretKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # massa-web3 ![Node CI](https://github.com/massalabs/massa-web3/workflows/Node.js%20CI/badge.svg)
 
-![check-code-coverage](https://img.shields.io/badge/coverage-44.61%25-red)
+![check-code-coverage](https://img.shields.io/badge/coverage-59.03%25-red)
 
 `Massa-web3` is a TypeScript library that allow you to interact with the `Massa` blockchain through a
 local or remote Massa node. In particular the massa-web3 library will allow you to call the JSON-RPC API,

--- a/src/web3/WalletClient.ts
+++ b/src/web3/WalletClient.ts
@@ -171,7 +171,11 @@ export class WalletClient extends BaseClient implements IWalletClient {
     }
     const accountsToCreate: IAccount[] = [];
 
-    for (const secretKeyBase58Encoded of secretKeys) {
+    const uniqueSecretKeys = secretKeys.filter(
+      (value, index, self) => self.indexOf(value) === index,
+    );
+
+    for (const secretKeyBase58Encoded of uniqueSecretKeys) {
       const secretKey = new SecretKey(secretKeyBase58Encoded);
       const publicKey: PublicKey = await secretKey.getPublicKey();
       const address: Address = new Address(publicKey);

--- a/test/web3/walletClient.spec.ts
+++ b/test/web3/walletClient.spec.ts
@@ -31,7 +31,7 @@ export async function initializeClient() {
   return web3Client;
 }
 
-describe.skip('WalletClient', () => {
+describe('WalletClient', () => {
   let web3Client: Client;
   // let walletClient: WalletClient;
   let baseAccount: IAccount = {
@@ -253,6 +253,85 @@ describe.skip('WalletClient', () => {
       expect(accountFromPrivateKey1.publicKey).not.toEqual(
         accountFromPrivateKey2.publicKey,
       );
+    });
+  });
+
+  describe('walletGenerateNewAccount', () => {
+    test('should generate a new account', async () => {
+      const newAccount = await WalletClient.walletGenerateNewAccount();
+      // Check that the newAccount object has all necessary properties
+      expect(newAccount).toHaveProperty('address');
+      expect(newAccount).toHaveProperty('secretKey');
+      expect(newAccount).toHaveProperty('publicKey');
+      expect(newAccount).toHaveProperty('createdInThread');
+
+      // Check that the properties are of correct type
+      expect(typeof newAccount.address).toBe('string');
+      expect(typeof newAccount.secretKey).toBe('string');
+      expect(typeof newAccount.publicKey).toBe('string');
+      expect(typeof newAccount.createdInThread).toBe('number');
+
+      // Check that the properties are not empty or null
+      expect(newAccount.address).not.toBeNull();
+      expect(newAccount.address).not.toBe('');
+      expect(newAccount.secretKey).not.toBeNull();
+      expect(newAccount.secretKey).not.toBe('');
+      expect(newAccount.publicKey).not.toBeNull();
+      expect(newAccount.publicKey).not.toBe('');
+
+      // Check that keys and address have the correct length
+      expect(newAccount.address?.length).toBeGreaterThanOrEqual(50);
+      expect(newAccount.secretKey?.length).toBeGreaterThanOrEqual(50);
+      expect(newAccount.publicKey?.length).toBeGreaterThanOrEqual(50);
+    });
+
+    test('should generate unique accounts each time', async () => {
+      const newAccount1 = await WalletClient.walletGenerateNewAccount();
+      const newAccount2 = await WalletClient.walletGenerateNewAccount();
+      expect(newAccount1).not.toEqual(newAccount2);
+    });
+  });
+
+  describe('getAccountFromSecretKey', () => {
+    test('should generate an account from a secret key', async () => {
+      const secretKey = 'S12syP5uCVEwaJwvXLqJyD1a2GqZjsup13UnhY6uzbtyu7ExXWZS';
+      const addressModel =
+        'AU12KgrLq2vhMgi8aAwbxytiC4wXBDGgvTtqGTM5R7wEB9En8WBHB';
+      const publicKeyModel =
+        'P12c2wsKxEyAhPC4ouNsgywzM41VsNSuwH9JdMbRt9bM8ZsMLPQA';
+      const createdInThreadModel = 21;
+      const accountFromSecretKey = await WalletClient.getAccountFromSecretKey(
+        secretKey,
+      );
+      // Check that the accountFromSecretKey object has all necessary properties
+      expect(accountFromSecretKey).toHaveProperty('address');
+      expect(accountFromSecretKey).toHaveProperty('secretKey');
+      expect(accountFromSecretKey).toHaveProperty('publicKey');
+      expect(accountFromSecretKey).toHaveProperty('createdInThread');
+      // Check that the secretKey matches the models
+      expect(accountFromSecretKey.address).toEqual(addressModel);
+      expect(accountFromSecretKey.publicKey).toEqual(publicKeyModel);
+      expect(accountFromSecretKey.secretKey).toEqual(secretKey);
+      expect(accountFromSecretKey.createdInThread).toEqual(
+        createdInThreadModel,
+      );
+    });
+
+    test('should throw error if invalid secret key is provided', async () => {
+      const invalidSecretKey = 'invalidSecretKey';
+      await expect(
+        WalletClient.getAccountFromSecretKey(invalidSecretKey),
+      ).rejects.toThrow();
+
+      const emptySecretKey = '';
+      await expect(
+        WalletClient.getAccountFromSecretKey(emptySecretKey),
+      ).rejects.toThrow();
+
+      const nullSecretKey = null;
+      await expect(
+        WalletClient.getAccountFromSecretKey(nullSecretKey as never),
+      ).rejects.toThrow();
     });
   });
 });


### PR DESCRIPTION
Since changes for testnet 23 have been merged, we don't need to skip tests anymore.
I've also fixed a test (should not add duplicate accounts to the wallet (duplicate in arguments) )