### PR TITLE
walletInfo, removeAddressesFromWallet, cleanWallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # massa-web3 ![Node CI](https://github.com/massalabs/massa-web3/workflows/Node.js%20CI/badge.svg)
 
-![check-code-coverage](https://img.shields.io/badge/coverage-59.03%25-red)
+![check-code-coverage](https://img.shields.io/badge/coverage-62.18%25-red)
 
 `Massa-web3` is a TypeScript library that allow you to interact with the `Massa` blockchain through a
 local or remote Massa node. In particular the massa-web3 library will allow you to call the JSON-RPC API,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # massa-web3 ![Node CI](https://github.com/massalabs/massa-web3/workflows/Node.js%20CI/badge.svg)
 
-![check-code-coverage](https://img.shields.io/badge/coverage-62.18%25-red)
+![check-code-coverage](https://img.shields.io/badge/coverage-64.45%25-red)
 
 `Massa-web3` is a TypeScript library that allow you to interact with the `Massa` blockchain through a
 local or remote Massa node. In particular the massa-web3 library will allow you to call the JSON-RPC API,

--- a/test/web3/walletClient.spec.ts
+++ b/test/web3/walletClient.spec.ts
@@ -12,8 +12,14 @@ const deployerPrivateKey =
 const receiverPrivateKey =
   'S1eK3SEXGDAWN6pZhdr4Q7WJv6UHss55EB14hPy4XqBpiktfPu6';
 
-const publicApi = 'http://127.0.0.1:33035';
-const privateApi = 'http://127.0.0.1:33034';
+// for CI testing:
+const publicApi = 'https://test.massa.net/api/v2:33035';
+const privateApi = 'https://test.massa.net/api/v2:33034';
+
+// For local testing:
+// const publicApi = 'http://127.0.0.1:33035';
+// const privateApi = 'http://127.0.0.1:33034';
+
 const MAX_WALLET_ACCOUNTS = 256;
 
 export async function initializeClient() {

--- a/test/web3/walletClient.spec.ts
+++ b/test/web3/walletClient.spec.ts
@@ -302,14 +302,6 @@ describe('WalletClient', () => {
         );
       });
     });
-
-    test.skip('should not throw error if an address to remove is not in the wallet', async () => {
-      const nonExistentAddress =
-        'AU12MvQVNNYtBx1VnM6dTvpEJzuqVAon48tccacXRyc5fwG5gZQn7';
-      await expect(
-        web3Client.wallet().removeAddressesFromWallet([nonExistentAddress]),
-      ).not.toThrow();
-    });
   });
 
   describe('cleanWallet', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
         "strictNullChecks": false,
         "downlevelIteration": true,
         "outDir": "dist",
-        "types": ["node"],
+        "types": ["node", "jest"],
         "typeRoots": ["node_modules/@types"],
         "lib": [
             "es7",


### PR DESCRIPTION
Idk if I have to do a test: "should throw an error if the number of retrieved wallets does not match the number of addresses in the wallet" for walletInfo, but I would have to mock getWalletAddressesInfo which is a private function.
Moreover, if we try to remove an address that isn't in the wallet, the function removeAddressesFromWallet crashes. Should we throw an error or not?