### PR TITLE
284 tests baseclient setProviders, getPrivateProviders & getPublicProviders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # massa-web3 ![Node CI](https://github.com/massalabs/massa-web3/workflows/Node.js%20CI/badge.svg)
 
-![check-code-coverage](https://img.shields.io/badge/coverage-61.31%25-red)
+![check-code-coverage](https://img.shields.io/badge/coverage-61.66%25-red)
 
 `Massa-web3` is a TypeScript library that allow you to interact with the `Massa` blockchain through a
 local or remote Massa node. In particular the massa-web3 library will allow you to call the JSON-RPC API,

--- a/src/web3/BaseClient.ts
+++ b/src/web3/BaseClient.ts
@@ -91,6 +91,25 @@ export class BaseClient {
    * @param providers - The new providers to set as an array of IProvider.
    */
   public setProviders(providers: Array<IProvider>): void {
+    const hasPublicProvider = providers.some(
+      (provider) => provider.type === ProviderType.PUBLIC,
+    );
+    const hasPrivateProvider = providers.some(
+      (provider) => provider.type === ProviderType.PRIVATE,
+    );
+
+    if (!hasPublicProvider) {
+      throw new Error(
+        'Cannot set providers with no public providers. Need at least one',
+      );
+    }
+
+    if (!hasPrivateProvider) {
+      throw new Error(
+        'Cannot set providers with no private providers. Need at least one',
+      );
+    }
+
     this.clientConfig.providers = providers;
   }
 

--- a/src/web3/BaseClient.ts
+++ b/src/web3/BaseClient.ts
@@ -99,7 +99,7 @@ export class BaseClient {
    *
    * @returns An array of IProvider containing all the private providers.
    */
-  protected getPrivateProviders(): Array<IProvider> {
+  public getPrivateProviders(): Array<IProvider> {
     return this.clientConfig.providers.filter(
       (provider) => provider.type === ProviderType.PRIVATE,
     );
@@ -110,7 +110,7 @@ export class BaseClient {
    *
    * @returns An array of IProvider containing all the public providers.
    */
-  protected getPublicProviders(): Array<IProvider> {
+  public getPublicProviders(): Array<IProvider> {
     return this.clientConfig.providers.filter(
       (provider) => provider.type === ProviderType.PUBLIC,
     );

--- a/test/web3/baseClient.spec.ts
+++ b/test/web3/baseClient.spec.ts
@@ -29,4 +29,23 @@ describe('BaseClient', () => {
       expect(privateProviders[0].type).toBe(ProviderType.PRIVATE);
     });
   });
+
+  describe('getPublicProviders', () => {
+    test('getPublicProviders should return an array of public providers', () => {
+      const clientConfig: IClientConfig = {
+        providers: [
+          { url: publicApi, type: ProviderType.PUBLIC } as IProvider,
+          { url: privateApi, type: ProviderType.PRIVATE } as IProvider,
+        ],
+        periodOffset: 0,
+      };
+
+      const baseClient = new BaseClient(clientConfig);
+      const publicProviders = baseClient.getPublicProviders();
+
+      expect(publicProviders).toHaveLength(1);
+      expect(publicProviders[0].url).toBe(publicApi);
+      expect(publicProviders[0].type).toBe(ProviderType.PUBLIC);
+    });
+  });
 });

--- a/test/web3/baseClient.spec.ts
+++ b/test/web3/baseClient.spec.ts
@@ -3,12 +3,12 @@ import { IProvider, ProviderType } from '../../src/interfaces/IProvider';
 import { IClientConfig } from '../../src/interfaces/IClientConfig';
 
 // for CI testing:
-// const publicApi = 'https://test.massa.net/api/v2:33035';
-// const privateApi = 'https://test.massa.net/api/v2:33034';
+const publicApi = 'https://test.massa.net/api/v2:33035';
+const privateApi = 'https://test.massa.net/api/v2:33034';
 
 // For local testing:
-const publicApi = 'http://127.0.0.1:33035';
-const privateApi = 'http://127.0.0.1:33034';
+// const publicApi = 'http://127.0.0.1:33035';
+// const privateApi = 'http://127.0.0.1:33034';
 
 export const PERIOD_OFFSET = 5;
 

--- a/test/web3/baseClient.spec.ts
+++ b/test/web3/baseClient.spec.ts
@@ -1,0 +1,32 @@
+import { BaseClient } from '../../src/web3/BaseClient';
+import { IProvider, ProviderType } from '../../src/interfaces/IProvider';
+import { IClientConfig } from '../../src/interfaces/IClientConfig';
+
+// for CI testing:
+// const publicApi = 'https://test.massa.net/api/v2:33035';
+// const privateApi = 'https://test.massa.net/api/v2:33034';
+
+// For local testing:
+const publicApi = 'http://127.0.0.1:33035';
+const privateApi = 'http://127.0.0.1:33034';
+
+describe('BaseClient', () => {
+  describe('getPrivateProviders', () => {
+    test('getPrivateProviders should return an array of private providers', () => {
+      const clientConfig: IClientConfig = {
+        providers: [
+          { url: publicApi, type: ProviderType.PUBLIC } as IProvider,
+          { url: privateApi, type: ProviderType.PRIVATE } as IProvider,
+        ],
+        periodOffset: 0,
+      };
+
+      const baseClient = new BaseClient(clientConfig);
+      const privateProviders = baseClient.getPrivateProviders();
+
+      expect(privateProviders).toHaveLength(1);
+      expect(privateProviders[0].url).toBe(privateApi);
+      expect(privateProviders[0].type).toBe(ProviderType.PRIVATE);
+    });
+  });
+});

--- a/test/web3/baseClient.spec.ts
+++ b/test/web3/baseClient.spec.ts
@@ -10,7 +10,133 @@ import { IClientConfig } from '../../src/interfaces/IClientConfig';
 const publicApi = 'http://127.0.0.1:33035';
 const privateApi = 'http://127.0.0.1:33034';
 
+export const PERIOD_OFFSET = 5;
+
 describe('BaseClient', () => {
+  describe('setProviders', () => {
+    test('setProviders should correctly set the new providers', () => {
+      const clientConfig: IClientConfig = {
+        providers: [
+          {
+            url: 'https://oldRpcUrlPublic/api',
+            type: ProviderType.PUBLIC,
+          } as IProvider,
+          {
+            url: 'https://oldRpcUrlPrivate/api',
+            type: ProviderType.PRIVATE,
+          } as IProvider,
+        ],
+        periodOffset: PERIOD_OFFSET,
+      };
+
+      const newProviders: Array<IProvider> = [
+        {
+          url: publicApi,
+          type: ProviderType.PUBLIC,
+        } as IProvider,
+        {
+          url: privateApi,
+          type: ProviderType.PRIVATE,
+        } as IProvider,
+      ];
+
+      const baseClient = new BaseClient(clientConfig);
+      const oldPrivateProviders = baseClient.getPrivateProviders();
+      const oldPublicProviders = baseClient.getPublicProviders();
+
+      baseClient.setProviders(newProviders);
+
+      const privateProviders = baseClient.getPrivateProviders();
+      const publicProviders = baseClient.getPublicProviders();
+
+      expect(oldPrivateProviders).toHaveLength(1);
+      expect(oldPrivateProviders[0].url).toBe('https://oldRpcUrlPrivate/api');
+      expect(oldPrivateProviders[0].type).toBe(ProviderType.PRIVATE);
+
+      expect(oldPublicProviders).toHaveLength(1);
+      expect(oldPublicProviders[0].url).toBe('https://oldRpcUrlPublic/api');
+      expect(oldPublicProviders[0].type).toBe(ProviderType.PUBLIC);
+
+      expect(privateProviders).toHaveLength(1);
+      expect(privateProviders[0].url).toBe(privateApi);
+      expect(privateProviders[0].type).toBe(ProviderType.PRIVATE);
+
+      expect(publicProviders).toHaveLength(1);
+      expect(publicProviders[0].url).toBe(publicApi);
+      expect(publicProviders[0].type).toBe(ProviderType.PUBLIC);
+    });
+
+    test('setProviders should throw an error when passed an empty array', () => {
+      const clientConfig: IClientConfig = {
+        providers: [
+          { url: publicApi, type: ProviderType.PUBLIC } as IProvider,
+          { url: privateApi, type: ProviderType.PRIVATE } as IProvider,
+        ],
+        periodOffset: PERIOD_OFFSET,
+      };
+
+      const baseClient = new BaseClient(clientConfig);
+
+      expect(() =>
+        baseClient.setProviders([
+          { url: privateApi, type: ProviderType.PRIVATE } as IProvider,
+        ]),
+      ).toThrow(
+        'Cannot set providers with no public providers. Need at least one',
+      );
+      expect(() =>
+        baseClient.setProviders([
+          { url: publicApi, type: ProviderType.PUBLIC } as IProvider,
+        ]),
+      ).toThrow(
+        'Cannot set providers with no private providers. Need at least one',
+      );
+    });
+
+    test('setProviders should correctly set multiple providers of the same type', () => {
+      const clientConfig: IClientConfig = {
+        providers: [
+          { url: publicApi, type: ProviderType.PUBLIC } as IProvider,
+          { url: privateApi, type: ProviderType.PRIVATE } as IProvider,
+        ],
+        periodOffset: PERIOD_OFFSET,
+      };
+
+      const newProviders: Array<IProvider> = [
+        {
+          url: 'http://new-public-api-1.com',
+          type: ProviderType.PUBLIC,
+        } as IProvider,
+        {
+          url: 'http://new-public-api-2.com',
+          type: ProviderType.PUBLIC,
+        } as IProvider,
+        {
+          url: 'http://new-private-api-1.com',
+          type: ProviderType.PRIVATE,
+        } as IProvider,
+        {
+          url: 'http://new-private-api-2.com',
+          type: ProviderType.PRIVATE,
+        } as IProvider,
+      ];
+
+      const baseClient = new BaseClient(clientConfig);
+      baseClient.setProviders(newProviders);
+
+      const privateProviders = baseClient.getPrivateProviders();
+      const publicProviders = baseClient.getPublicProviders();
+
+      expect(privateProviders).toHaveLength(2);
+      expect(privateProviders[0].url).toBe('http://new-private-api-1.com');
+      expect(privateProviders[1].url).toBe('http://new-private-api-2.com');
+
+      expect(publicProviders).toHaveLength(2);
+      expect(publicProviders[0].url).toBe('http://new-public-api-1.com');
+      expect(publicProviders[1].url).toBe('http://new-public-api-2.com');
+    });
+  });
+
   describe('getPrivateProviders', () => {
     test('getPrivateProviders should return an array of private providers', () => {
       const clientConfig: IClientConfig = {
@@ -18,7 +144,7 @@ describe('BaseClient', () => {
           { url: publicApi, type: ProviderType.PUBLIC } as IProvider,
           { url: privateApi, type: ProviderType.PRIVATE } as IProvider,
         ],
-        periodOffset: 0,
+        periodOffset: PERIOD_OFFSET,
       };
 
       const baseClient = new BaseClient(clientConfig);
@@ -37,7 +163,7 @@ describe('BaseClient', () => {
           { url: publicApi, type: ProviderType.PUBLIC } as IProvider,
           { url: privateApi, type: ProviderType.PRIVATE } as IProvider,
         ],
-        periodOffset: 0,
+        periodOffset: PERIOD_OFFSET,
       };
 
       const baseClient = new BaseClient(clientConfig);


### PR DESCRIPTION
At the moment we can set several publicProviders or several privateProviders at the same time, is it something that we want ? 
Moreover, most of the functions tested here are `protected`, so we need to put them `public` to test it. Idk if it's a problem