### PR TITLE
358 test smartcontractsclient executereadonlysmartcontract

### DIFF
--- a/test/web3/mockData.ts
+++ b/test/web3/mockData.ts
@@ -16,6 +16,7 @@ import { IEvent } from '../../src/interfaces/IEvent';
 import { ISlot } from '../../src/interfaces/ISlot';
 import { IEventFilter } from '../../src/interfaces/IEventFilter';
 import { IEventRegexFilter } from '../../src/interfaces/IEventRegexFilter';
+import { IExecuteReadOnlyResponse } from '../../src/interfaces/IExecuteReadOnlyResponse';
 
 // util function to create an event, only for that test file to avoid code duplication
 function createEvent(
@@ -365,6 +366,7 @@ export const mockContractData: IContractData = {
   fee: 100000000000000000n,
   maxGas: 100000000000000000n,
   maxCoins: 100000000000000000n,
+  address: 'AU1fMUjzAR6Big9Woz3P3vTjAywLbb9KwSyC8btfK3KMDj8ffAHu',
   contractDataText: 'Hello World!',
   contractDataBinary: new Uint8Array([0x00, 0x01, 0x02, 0x03]),
   datastore: new Map<Uint8Array, Uint8Array>([
@@ -465,3 +467,8 @@ export const mockContractReadOperationResponse: IContractReadOperationResponse =
     returnValue: new Uint8Array([0x00, 0x01, 0x02, 0x03]),
     info: mockContractReadOperationData[0],
   };
+
+export const mockContractReadOnlyOperationResponse: IExecuteReadOnlyResponse = {
+  returnValue: new Uint8Array([0x00, 0x01, 0x02, 0x03]),
+  info: mockContractReadOperationData[0],
+};

--- a/test/web3/smartContractsClient.spec.ts
+++ b/test/web3/smartContractsClient.spec.ts
@@ -608,7 +608,8 @@ describe('SmartContractsClient', () => {
     });
 
     test('should return correct result', async () => {
-      const expectedResponse: IExecuteReadOnlyResponse = mockContractReadOnlyOperationResponse;
+      const expectedResponse: IExecuteReadOnlyResponse =
+        mockContractReadOnlyOperationResponse;
 
       (smartContractsClient as any).sendJsonRPCRequest = jest
         .fn()

--- a/test/web3/smartContractsClient.spec.ts
+++ b/test/web3/smartContractsClient.spec.ts
@@ -85,6 +85,11 @@ describe('SmartContractsClient', () => {
   });
 
   describe('deploySmartContract', () => {
+    let consoleWarnSpy: jest.SpyInstance;
+    beforeEach(() => {
+      consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
     test('should call sendJsonRPCRequest with correct arguments', async () => {
       await smartContractsClient.deploySmartContract(
         mockContractData,
@@ -137,14 +142,12 @@ describe('SmartContractsClient', () => {
     });
 
     test('should warn when contractDataBinary size exceeded half of the maximum size of a block', async () => {
+      consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
       const max_block_size = mockNodeStatusInfo.config.max_block_size;
       mockContractData.contractDataBinary = new Uint8Array(
         max_block_size / 2 + 1,
       ); // value > max_block_size / 2
-
-      const consoleWarnSpy = jest
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {});
 
       await smartContractsClient.deploySmartContract(mockContractData);
 
@@ -179,6 +182,7 @@ describe('SmartContractsClient', () => {
       );
     });
   });
+
   describe('callSmartContract', () => {
     test('should call sendJsonRPCRequest with correct arguments', async () => {
       await smartContractsClient.callSmartContract(

--- a/test/web3/smartContractsClient.spec.ts
+++ b/test/web3/smartContractsClient.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { IBalance } from '../../src/interfaces/IBalance';
 import { JSON_RPC_REQUEST_METHOD } from '../../src/interfaces/JsonRpcMethods';
@@ -141,9 +142,9 @@ describe('SmartContractsClient', () => {
         max_block_size / 2 + 1,
       ); // value > max_block_size / 2
 
-      const consoleWarnSpy = jest.spyOn(console, 'warn');
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      consoleWarnSpy.mockImplementation(() => {});
+      const consoleWarnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
 
       await smartContractsClient.deploySmartContract(mockContractData);
 
@@ -444,6 +445,10 @@ describe('SmartContractsClient', () => {
         .fn()
         .mockRejectedValue(new Error(expectedErrorMessage));
 
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
       const error = await smartContractsClient
         .awaitRequiredOperationStatus(opId, requiredStatus)
         .catch((e) => e);
@@ -453,6 +458,9 @@ describe('SmartContractsClient', () => {
       expect(smartContractsClient.getOperationStatus).toHaveBeenCalledTimes(
         101,
       );
+
+      // Restore console.error
+      consoleErrorSpy.mockRestore();
     });
 
     test('fails after reaching the pending limit', async () => {
@@ -460,6 +468,10 @@ describe('SmartContractsClient', () => {
       smartContractsClient.getOperationStatus = jest
         .fn()
         .mockResolvedValue(EOperationStatus.NOT_FOUND);
+
+      const consoleWarnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
 
       await expect(
         smartContractsClient.awaitRequiredOperationStatus(opId, requiredStatus),
@@ -472,6 +484,9 @@ describe('SmartContractsClient', () => {
       expect(smartContractsClient.getOperationStatus).toHaveBeenCalledTimes(
         1001,
       );
+
+      // Restore console.warn
+      consoleWarnSpy.mockRestore();
     });
   });
 
@@ -565,6 +580,10 @@ describe('SmartContractsClient', () => {
 
   describe('executeReadOnlySmartContract', () => {
     test('should throw error if contractDataBinary is missing', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
       await expect(
         smartContractsClient.executeReadOnlySmartContract({
           ...mockContractData,
@@ -573,6 +592,9 @@ describe('SmartContractsClient', () => {
       ).rejects.toThrow(
         `Expected non-null contract bytecode, but received null.`,
       );
+
+      // Restore console.error
+      consoleErrorSpy.mockRestore();
     });
 
     test('should throw error if address is missing', async () => {

--- a/test/web3/smartContractsClient.spec.ts
+++ b/test/web3/smartContractsClient.spec.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-empty-function, @typescript-eslint/no-explicit-any */
 import { IBalance } from '../../src/interfaces/IBalance';
 import { JSON_RPC_REQUEST_METHOD } from '../../src/interfaces/JsonRpcMethods';
 import { EOperationStatus } from '../../src/interfaces/EOperationStatus';


### PR DESCRIPTION
tests of executereadonlysmartcontract + removing console.warn and console.error while jest is running tests