### PR TITLE
360 mock tests getaccountbalance + small additional tests

### DIFF
--- a/src/web3/WalletClient.ts
+++ b/src/web3/WalletClient.ts
@@ -548,7 +548,10 @@ export class WalletClient extends BaseClient implements IWalletClient {
     try {
       const addresses: Array<IAddressInfo> =
         await this.publicApiClient.getAddresses([address]);
-      if (addresses.length === 0) return null;
+      if (addresses.length === 0) {
+        console.log('addresses.length === 0');
+        return null;
+      }
       const addressInfo: IAddressInfo = addresses.at(0);
       return {
         candidate: fromMAS(addressInfo.candidate_balance),

--- a/src/web3/WalletClient.ts
+++ b/src/web3/WalletClient.ts
@@ -548,10 +548,8 @@ export class WalletClient extends BaseClient implements IWalletClient {
     try {
       const addresses: Array<IAddressInfo> =
         await this.publicApiClient.getAddresses([address]);
-      if (addresses.length === 0) {
-        console.log('addresses.length === 0');
-        return null;
-      }
+      if (addresses.length === 0) return null;
+
       const addressInfo: IAddressInfo = addresses.at(0);
       return {
         candidate: fromMAS(addressInfo.candidate_balance),

--- a/test/web3/walletClient.spec.ts
+++ b/test/web3/walletClient.spec.ts
@@ -518,6 +518,24 @@ describe('WalletClient', () => {
       expect(typeof signedMessage.base58Encoded).toBe('string');
       expect(signedMessage.base58Encoded).toEqual(modelSignedMessage);
     });
+
+    test('should throw an error if the signature could not be verified with the public key', async () => {
+      const data = 'Test message';
+      const signer = baseAccount;
+
+      // Create a spy on the 'verify' function to provide an incorrect mock implementation for this test
+      const verifySpy = jest.spyOn(ed, 'verify');
+      verifySpy.mockImplementation(() => Promise.resolve(false)); // always return false
+
+      await expect(
+        WalletClient.walletSignMessage(data, signer),
+      ).rejects.toThrow(
+        'Signature could not be verified with public key. Please inspect',
+      );
+
+      // Restore the original 'verify' function after the test
+      verifySpy.mockRestore();
+    });
   });
 
   describe('signMessage', () => {

--- a/test/web3/walletClient.spec.ts
+++ b/test/web3/walletClient.spec.ts
@@ -15,11 +15,7 @@ import { mockResultSendJsonRPCRequestWalletInfo } from '../../src/web3/mockData'
 import { ITransactionData } from '../../src/interfaces/ITransactionData';
 import { OperationTypeId } from '../../src/interfaces/OperationTypes';
 import { JSON_RPC_REQUEST_METHOD } from '../../src/interfaces/JsonRpcMethods';
-import {
-  mockAddressesInfo,
-  mockNodeStatusInfo,
-  mockOpIds,
-} from './mockData';
+import { mockAddressesInfo, mockNodeStatusInfo, mockOpIds } from './mockData';
 import { IRollsData } from '../../src/interfaces/IRollsData';
 import { fromMAS } from '../../src/utils/converters';
 

--- a/test/web3/walletClient.spec.ts
+++ b/test/web3/walletClient.spec.ts
@@ -1,6 +1,4 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-empty-function, @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-var-requires */
 import { IAccount } from '../../src/interfaces/IAccount';
 import { ClientFactory } from '../../src/web3/ClientFactory';
 import { WalletClient } from '../../src/web3/WalletClient';


### PR DESCRIPTION
- mock getAddresses calls in tests of getAccountBalance so we can run tests without to call a node
- add a test for walletSignMessage to check that we throw an error when the signature could not be verified