### PR TITLE
Convert datastore entries to real uint8Array

### DIFF
--- a/src/web3/PublicApiClient.ts
+++ b/src/web3/PublicApiClient.ts
@@ -299,10 +299,10 @@ export class PublicApiClient extends BaseClient implements IPublicApiClient {
         [data],
       );
     }
-    return datastoreEntries.map((entry) => {
+    return datastoreEntries.map((e) => {
       return {
-        final_value: new Uint8Array(entry.final_value),
-        candidate_value: new Uint8Array(entry.candidate_value),
+        final_value: new Uint8Array(e.final_value),
+        candidate_value: new Uint8Array(e.candidate_value),
       } as IDatastoreEntry;
     });
   }

--- a/src/web3/PublicApiClient.ts
+++ b/src/web3/PublicApiClient.ts
@@ -299,10 +299,11 @@ export class PublicApiClient extends BaseClient implements IPublicApiClient {
         [data],
       );
     }
-    datastoreEntries.map((entry) => {
-      entry.final_value = new Uint8Array(entry.final_value);
-      entry.candidate_value = new Uint8Array(entry.candidate_value);
+    return datastoreEntries.map((entry) => {
+      return {
+        final_value: new Uint8Array(entry.final_value),
+        candidate_value: new Uint8Array(entry.candidate_value),
+      } as IDatastoreEntry;
     });
-    return datastoreEntries;
   }
 }

--- a/src/web3/PublicApiClient.ts
+++ b/src/web3/PublicApiClient.ts
@@ -299,6 +299,10 @@ export class PublicApiClient extends BaseClient implements IPublicApiClient {
         [data],
       );
     }
+    for (let entry of datastoreEntries) {
+      entry.final_value = new Uint8Array(entry.final_value);
+      entry.candidate_value = new Uint8Array(entry.candidate_value);
+    }
     return datastoreEntries;
   }
 }

--- a/src/web3/PublicApiClient.ts
+++ b/src/web3/PublicApiClient.ts
@@ -303,7 +303,7 @@ export class PublicApiClient extends BaseClient implements IPublicApiClient {
       return {
         final_value: new Uint8Array(e.final_value),
         candidate_value: new Uint8Array(e.candidate_value),
-      } as IDatastoreEntry;
+      };
     });
   }
 }

--- a/src/web3/PublicApiClient.ts
+++ b/src/web3/PublicApiClient.ts
@@ -299,10 +299,10 @@ export class PublicApiClient extends BaseClient implements IPublicApiClient {
         [data],
       );
     }
-    for (let entry of datastoreEntries) {
+    datastoreEntries.map((entry) => {
       entry.final_value = new Uint8Array(entry.final_value);
       entry.candidate_value = new Uint8Array(entry.candidate_value);
-    }
+    });
     return datastoreEntries;
   }
 }


### PR DESCRIPTION
Fix of the error : 
```
ERROR
Failed to execute 'decode' on 'TextDecoder': The provided value is not of type '(ArrayBuffer or ArrayBufferView)'.
TypeError: Failed to execute 'decode' on 'TextDecoder': The provided value is not of type '(ArrayBuffer or ArrayBufferView)'.
    at bytesToStr (http://localhost:3001/static/js/bundle.js:2370:22)
    at funcGetGreeting (http://localhost:3001/static/js/bundle.js:73:96)
```
in quickstart code.

Part of  https://github.com/massalabs/docu-dev/issues/131 