### PR TITLE
add a readSmartContract method 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ export {
   SmartContractsClient,
   MASSA_PROTOFILE_KEY,
   PROTO_FILE_SEPARATOR,
+  readSmartContract,
 } from './web3/SmartContractsClient';
 export * from './utils/arguments';
 export { fromMAS, toMAS, MassaUnits } from './utils/converters';

--- a/src/web3/SmartContractsClient.ts
+++ b/src/web3/SmartContractsClient.ts
@@ -599,7 +599,7 @@ async function promisifyJsonRpcCall<T>(
 
   return {
     isError: false,
-    result: responseData.result as T,
+    result: responseData.result,
     error: null,
   } as JsonRpcResponseData<T>;
 }

--- a/src/web3/SmartContractsClient.ts
+++ b/src/web3/SmartContractsClient.ts
@@ -543,7 +543,7 @@ async function sendJsonRPCRequest<T>(
   resp = await promisifyJsonRpcCall(resource, params, rpcUrl);
 
   // in case of rpc error, rethrow the error.
-  if (resp.error && resp.error) {
+  if (resp.error) {
     throw resp.error;
   }
 


### PR DESCRIPTION
add a readSmartContract method that could be called without initiating a smartContractClient

should be used like this:
```typescript
console.log(await readSmartContract(
        {
            maxGas: maxGas,
            targetAddress: address,
            targetFunction: fctName,
            parameter: arguments,
            callerAddress: callerAddress,
        },
        rpcUrl,
    ));
```



closes #412 
cc @leoloco 