### PR TITLE
readonly: keep blank the optional parameters

### DIFF
--- a/packages/massa-web3/src/web3/SmartContractsClient.ts
+++ b/packages/massa-web3/src/web3/SmartContractsClient.ts
@@ -178,26 +178,47 @@ export class SmartContractsClient
       )
     }
 
-    if (readData.maxGas === null || readData.maxGas === undefined) {
-      readData.maxGas = BigInt(MAX_GAS_CALL)
+    interface ContractReadOperationData {
+      max_gas?: number
+      target_address: string
+      target_function: string
+      parameter?: number[]
+      caller_address?: string
+      coins?: string
+      fee?: string
     }
 
-    if (readData.parameter instanceof Args)
-      readData.parameter = readData.parameter.serialize()
-
-    // request data
-    let baseAccountSignerAddress: string | null = null
-    if (this.walletClient.getBaseAccount()) {
-      baseAccountSignerAddress = this.walletClient.getBaseAccount().address()
-    }
-    const data = {
-      max_gas: Number(readData.maxGas),
+    const data: ContractReadOperationData = {
       target_address: readData.targetAddress,
       target_function: readData.targetFunction,
-      parameter: readData.parameter,
-      caller_address: readData.callerAddress || baseAccountSignerAddress,
-      coins: toMAS(readData.coins || BigInt(0)).toString(),
-      fee: readData.fee?.toString(),
+    }
+
+    if (readData.callerAddress) {
+      data.caller_address = readData.callerAddress
+    } else {
+      if (this.walletClient.getBaseAccount()) {
+        data.caller_address = this.walletClient.getBaseAccount().address()
+      }
+    }
+
+    if (readData.parameter instanceof Args) {
+      data.parameter = readData.parameter.serialize()
+    } else {
+      data.parameter = readData.parameter
+    }
+
+    if (readData.maxGas === null || readData.maxGas === undefined) {
+      data.max_gas = Number(MAX_GAS_CALL)
+    } else {
+      data.max_gas = Number(readData.maxGas)
+    }
+
+    if (readData.coins) {
+      data.coins = toMAS(readData.coins).toString()
+    }
+
+    if (readData.fee) {
+      data.fee = readData.fee.toString()
     }
 
     // returns operation ids

--- a/packages/massa-web3/src/web3/SmartContractsClient.ts
+++ b/packages/massa-web3/src/web3/SmartContractsClient.ts
@@ -178,47 +178,22 @@ export class SmartContractsClient
       )
     }
 
-    interface ContractReadOperationData {
-      max_gas?: number
-      target_address: string
-      target_function: string
-      parameter?: number[]
-      caller_address?: string
-      coins?: string
-      fee?: string
-    }
-
-    const data: ContractReadOperationData = {
+    const data = {
+      max_gas:
+        readData.maxGas === null || readData.maxGas === undefined
+          ? Number(MAX_GAS_CALL)
+          : Number(readData.maxGas),
       target_address: readData.targetAddress,
       target_function: readData.targetFunction,
-    }
-
-    if (readData.callerAddress) {
-      data.caller_address = readData.callerAddress
-    } else {
-      if (this.walletClient.getBaseAccount()) {
-        data.caller_address = this.walletClient.getBaseAccount().address()
-      }
-    }
-
-    if (readData.parameter instanceof Args) {
-      data.parameter = readData.parameter.serialize()
-    } else {
-      data.parameter = readData.parameter
-    }
-
-    if (readData.maxGas === null || readData.maxGas === undefined) {
-      data.max_gas = Number(MAX_GAS_CALL)
-    } else {
-      data.max_gas = Number(readData.maxGas)
-    }
-
-    if (readData.coins) {
-      data.coins = toMAS(readData.coins).toString()
-    }
-
-    if (readData.fee) {
-      data.fee = readData.fee.toString()
+      parameter:
+        readData.parameter instanceof Args
+          ? readData.parameter.serialize()
+          : readData.parameter,
+      caller_address: readData.callerAddress
+        ? readData.callerAddress
+        : this.walletClient.getBaseAccount()?.address(),
+      coins: readData.coins ? toMAS(readData.coins).toString() : undefined,
+      fee: readData.fee?.toString(),
     }
 
     // returns operation ids


### PR DESCRIPTION
when parameter coins or fee are defined (0 or more), the node try to send from caller_address, if caller_address is undefined, the node take the address of the node, but if this address is not in the ledger, the readonly call fails. 

So, if user don't provide fee, then we must pass fee = undefined (this was already done),
if user don't provide coins, we must pass coins = undefined (this PR do it).

In this PR, I refactor also the other parameters, we can discuss that in the code review. I did 2 commits, one for each proposition of the function readSmartContract.