### PR TITLE
Add get minimal fees method

### DIFF
--- a/packages/massa-web3/src/interfaces/INodeStatus.ts
+++ b/packages/massa-web3/src/interfaces/INodeStatus.ts
@@ -71,4 +71,5 @@ export interface INodeStatus {
   pool_stats: { endorsement_count: number; operation_count: number }
   version: string
   chain_id: bigint
+  minimal_fees?: string
 }

--- a/packages/massa-web3/src/interfaces/IPublicApiClient.ts
+++ b/packages/massa-web3/src/interfaces/IPublicApiClient.ts
@@ -115,4 +115,11 @@ export interface IPublicApiClient extends BaseClient {
   getGraphInterval(
     graphInterval: IGetGraphInterval
   ): Promise<Array<IGraphInterval>>
+
+  /**
+   * Get the minimal fees required for your operation to be accepted by the API provider
+   *
+   * @returns The minimal fees as bigint (in nano-MAS).
+   */
+  getMinimalFees(): Promise<bigint>
 }

--- a/packages/massa-web3/src/web3/PublicApiClient.ts
+++ b/packages/massa-web3/src/web3/PublicApiClient.ts
@@ -15,7 +15,7 @@ import { IDatastoreEntryInput } from '../interfaces/IDatastoreEntryInput'
 import { IGetGraphInterval } from '../interfaces/IGetGraphInterval'
 import { IGraphInterval } from '../interfaces/IGraphInterval'
 import { IBlockcliqueBlockBySlot } from '../interfaces/IBlockcliqueBlockBySlot'
-import { ISlot, MASSA_SCALING_FACTOR } from '@massalabs/web3-utils'
+import { ISlot, fromMAS } from '@massalabs/web3-utils'
 
 /**
  * Public API client for interacting with a Massa node.
@@ -152,7 +152,7 @@ export class PublicApiClient extends BaseClient implements IPublicApiClient {
       )
       fees = result.minimal_fees || '0'
     }
-    return BigInt(parseFloat(fees) * 10 ** MASSA_SCALING_FACTOR)
+    return fromMAS(fees)
   }
 
   /**

--- a/packages/massa-web3/src/web3/PublicApiClient.ts
+++ b/packages/massa-web3/src/web3/PublicApiClient.ts
@@ -134,7 +134,7 @@ export class PublicApiClient extends BaseClient implements IPublicApiClient {
   /**
    * Retrieves the minimal fees for operations to be accepted by the API provider.
    *
-   * @returns The minimal fees as a string (in nano-MAS).
+   * @returns The minimal fees as a bigint (in nano-MAS).
    */
   public async getMinimalFees(): Promise<bigint> {
     const jsonRpcRequestMethod = JSON_RPC_REQUEST_METHOD.GET_STATUS


### PR DESCRIPTION
Tested with a sandbox node.

The usage is : 
```
console.log(await web3Client.publicApi().getMinimalFees());
```
Output (with default minimal fees) : 
```
10000000n
```