### PR TITLE
Fix(packages/massa-web3): removed axios to use fetch in BaseClient

### DIFF
--- a/packages/massa-web3/test/web3/baseClient.spec.ts
+++ b/packages/massa-web3/test/web3/baseClient.spec.ts
@@ -3,7 +3,7 @@ import { IProvider, ProviderType } from '../../src/interfaces/IProvider'
 import { IClientConfig } from '../../src/interfaces/IClientConfig'
 import { JSON_RPC_REQUEST_METHOD } from '../../src/interfaces/JsonRpcMethods'
 import axios from 'axios'
-import { requestHeaders } from '../../src/web3/BaseClient'
+import { fetchRequestHeaders } from '../../src/web3/BaseClient'
 
 jest.mock('axios')
 
@@ -226,72 +226,90 @@ describe('BaseClient', () => {
 
     test('should use public provider for public RPC methods', async () => {
       const mockResponse = {
-        data: {
-          result: {
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            result: {
+              error: null,
+              isError: false,
+              result: 'some data returned from the API',
+            },
             error: null,
             isError: false,
-            result: 'some data returned from the API',
-          },
-          error: null,
-          isError: false,
-        },
+          }),
       }
 
-      mockAxios.post.mockResolvedValueOnce(mockResponse)
+      const mockFetch = jest
+        .spyOn(global, 'fetch')
+        .mockImplementation(
+          jest.fn(() => Promise.resolve(mockResponse)) as jest.Mock
+        )
 
       const result = await baseClient.getSendJsonRPCRequest(
         JSON_RPC_REQUEST_METHOD.GET_STATUS, // public method
         {}
       )
 
-      expect(mockAxios.post).toHaveBeenCalledTimes(1)
-      expect(mockAxios.post).toHaveBeenCalledWith(
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledWith(
         publicApi, // <-- We check here that the public API is used
         {
-          jsonrpc: '2.0',
-          id: 0,
-          method: JSON_RPC_REQUEST_METHOD.GET_STATUS,
-          params: {},
-        },
-        requestHeaders
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: JSON_RPC_REQUEST_METHOD.GET_STATUS,
+            params: {},
+            id: 0,
+          }),
+          method: 'POST',
+          headers: fetchRequestHeaders,
+        }
       )
 
-      expect(result).toEqual(mockResponse.data.result)
+      expect(result).toEqual((await mockResponse.json()).result)
     })
 
     test('should use private provider for private RPC methods', async () => {
       const mockResponse = {
-        data: {
-          result: {
+        json: () =>
+          Promise.resolve({
+            result: {
+              error: null,
+              isError: false,
+              result: 'some data returned from the API',
+            },
             error: null,
             isError: false,
-            result: 'some data returned from the API',
-          },
-          error: null,
-          isError: false,
-        },
+          }),
       }
 
-      mockAxios.post.mockResolvedValueOnce(mockResponse)
+      const mockFetch = jest
+        .spyOn(global, 'fetch')
+        .mockImplementation(
+          jest.fn(() => Promise.resolve(mockResponse)) as jest.Mock
+        )
 
       const result = await baseClient.getSendJsonRPCRequest(
         JSON_RPC_REQUEST_METHOD.STOP_NODE, // private method
         {}
       )
 
-      expect(mockAxios.post).toHaveBeenCalledTimes(1)
-      expect(mockAxios.post).toHaveBeenCalledWith(
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledWith(
         privateApi, // <-- We check here that the private API is used
         {
-          jsonrpc: '2.0',
-          id: 0,
-          method: JSON_RPC_REQUEST_METHOD.STOP_NODE,
-          params: {},
-        },
-        requestHeaders
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: JSON_RPC_REQUEST_METHOD.STOP_NODE,
+            params: {},
+            id: 0,
+          }),
+          headers: fetchRequestHeaders,
+          method: 'POST',
+        }
       )
 
-      expect(result).toEqual(mockResponse.data.result)
+      expect(result).toEqual((await mockResponse.json()).result)
     })
 
     test('should throw an error for unknown RPC methods', async () => {
@@ -338,18 +356,25 @@ describe('BaseClient', () => {
 
     test('should handle JSON-RPC error responses', async () => {
       const mockResponse = {
-        data: {
-          result: null,
-          error: {
-            code: -32600,
-            message: 'Invalid Request',
-          },
-          id: null,
-          jsonrpc: '2.0',
-        },
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            result: null,
+            error: {
+              code: -32600,
+              message: 'Invalid Request',
+            },
+            id: null,
+            jsonrpc: '2.0',
+          }),
       }
 
-      mockAxios.post.mockResolvedValueOnce(mockResponse)
+      jest
+        .spyOn(global, 'fetch')
+        .mockImplementation(
+          jest.fn(() => Promise.resolve(mockResponse)) as jest.Mock
+        )
 
       await expect(
         baseClient.getSendJsonRPCRequest(JSON_RPC_REQUEST_METHOD.GET_STATUS, {})


### PR DESCRIPTION
Hello,

This PR replaces Axios by the native fetch function in order to use this package in the Metamask snap bounty (see Secure ECMAScript requirements).

Thanks in advance for your review.