### PR TITLE
Add  Massa name resolution

### DIFF
--- a/packages/massa-web3/examples/smartContracts/deployer.ts
+++ b/packages/massa-web3/examples/smartContracts/deployer.ts
@@ -79,7 +79,7 @@ export const deploySmartContracts = async (
   contractsToDeploy: ISCData[],
   web3Client: Client,
   deployerAccount: IBaseAccount,
-  fee = 0n,
+  fee = fromMAS(0.01),
   maxGas = MAX_GAS_DEPLOYMENT,
   maxCoins = fromMAS(0.1)
 ): Promise<string> => {

--- a/packages/massa-web3/examples/smartContracts/index.ts
+++ b/packages/massa-web3/examples/smartContracts/index.ts
@@ -214,7 +214,7 @@ const pollAsyncEvents = async (
       ],
       web3Client,
       baseAccount,
-      0n,
+      fromMAS(0.01),
       3000_000_000n,
       fromMAS(1.5)
     )
@@ -270,7 +270,7 @@ const pollAsyncEvents = async (
       targetFunction: 'getMusicAlbum',
       parameter: args.serialize(),
       coins: 0n,
-      fee: 0n,
+      fee: fromMAS(0.01),
     })
 
     const res = new Args(result.returnValue, 0)
@@ -288,7 +288,7 @@ const pollAsyncEvents = async (
     const deleteMusicAlbumCallOperationId = await web3Client
       .smartContracts()
       .callSmartContract({
-        fee: 0n,
+        fee: fromMAS(0.01),
         coins: 0n,
         targetAddress: scAddress,
         targetFunction: 'deleteMusicAlbum',
@@ -317,7 +317,7 @@ const pollAsyncEvents = async (
     const createMusicAlbumCallOperationId = await web3Client
       .smartContracts()
       .callSmartContract({
-        fee: 0n,
+        fee: fromMAS(0.01),
         coins: 0n,
         targetAddress: scAddress,
         targetFunction: 'addMusicAlbum',

--- a/packages/massa-web3/examples/smartContracts/nameResolver.ts
+++ b/packages/massa-web3/examples/smartContracts/nameResolver.ts
@@ -1,0 +1,159 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable no-console */
+import { IAccount } from '../../src/interfaces/IAccount'
+import { ClientFactory } from '../../src/web3/ClientFactory'
+import { WalletClient } from '../../src/web3/WalletClient'
+import { Client } from '../../src/web3/Client'
+import { ICallData } from '../../src/interfaces/ICallData'
+import * as dotenv from 'dotenv'
+import { IProvider, ProviderType } from '../../src/interfaces/IProvider'
+import {
+  Args,
+  CHAIN_ID,
+  EOperationStatus,
+  ITransactionData,
+  fromMAS,
+} from '../../src'
+import { getEnvVariable } from '../utils'
+
+const path = require('path')
+const chalk = require('chalk')
+const ora = require('ora')
+
+dotenv.config({
+  path: path.resolve(__dirname, '..', '.env'),
+})
+
+const publicApi = getEnvVariable('JSON_RPC_URL_PUBLIC')
+const privateApi = getEnvVariable('JSON_RPC_URL_PRIVATE')
+const chainId = CHAIN_ID.BuildNet
+const privateKey = getEnvVariable('DEPLOYER_PRIVATE_KEY')
+
+;(async () => {
+  const header = '='.repeat(process.stdout.columns - 1)
+  console.log(header)
+  console.log(`${chalk.green.bold('Massa Name Service Resolver Example')}`)
+  console.log(header)
+
+  let spinner
+  try {
+    // init client
+    const deployerAccount: IAccount =
+      await WalletClient.getAccountFromSecretKey(privateKey)
+    const web3Client: Client = await ClientFactory.createCustomClient(
+      [
+        { url: publicApi, type: ProviderType.PUBLIC } as IProvider,
+        { url: privateApi, type: ProviderType.PRIVATE } as IProvider,
+      ],
+      chainId,
+      true,
+      deployerAccount
+    )
+
+    // Try to register a domain
+    const domain = 'example'
+    const address = deployerAccount.address as string
+
+    spinner = ora('Trying to create the domain').start()
+    try {
+      const domainCreationOpId = await web3Client
+        .smartContracts()
+        .callSmartContract({
+          fee: fromMAS(0.01),
+          coins: fromMAS(2),
+          targetAddress: web3Client.mnsResolver().getMnsResolverAddress(),
+          targetFunction: 'dnsAlloc',
+          parameter: new Args()
+            .addString(domain)
+            .addString(address)
+            .serialize(),
+        } as ICallData)
+      await web3Client
+        .smartContracts()
+        .awaitMultipleRequiredOperationStatus(domainCreationOpId, [
+          EOperationStatus.SPECULATIVE_SUCCESS,
+          EOperationStatus.SPECULATIVE_ERROR,
+        ])
+      spinner.succeed('Domain created successfully')
+    } catch (ex) {
+      spinner.succeed('Domain already exists')
+    }
+
+    // Try to resolve the domain
+    spinner = ora('Trying to resolve the domain').start()
+    const resolvedAddress = await web3Client
+      .mnsResolver()
+      .resolve(domain + '.massa')
+    spinner.succeed(`Domain resolved to address ${resolvedAddress}`)
+
+    // Try to send a transaction to the resolved address
+    spinner = ora(
+      'Trying to send a transaction to the resolved address'
+    ).start()
+    const txData = {
+      amount: fromMAS(1),
+      recipientAddress: resolvedAddress,
+      fee: fromMAS(0.01),
+    } as ITransactionData
+    const txOpId = await web3Client.wallet().sendTransaction(txData)
+    await web3Client
+      .smartContracts()
+      .awaitMultipleRequiredOperationStatus(txOpId[0], [
+        EOperationStatus.SPECULATIVE_SUCCESS,
+      ])
+    spinner.succeed('Transaction sent successfully')
+    // Try to call a function on the resolved address
+    spinner = ora('Trying to call a function on the resolved address').start()
+    const callData = {
+      fee: fromMAS(0.01),
+      coins: fromMAS(1),
+      targetAddress: resolvedAddress,
+      targetFunction: 'getBalance',
+      parameter: new Args().serialize(),
+    } as ICallData
+    try {
+      await web3Client.smartContracts().callSmartContract(callData)
+    } catch (ex) {
+      if (
+        ex.message.endsWith(
+          `The called address ${resolvedAddress} is not a smart contract address`
+        )
+      ) {
+        spinner.succeed('Call smart contract resolved address successfully')
+      } else {
+        spinner.fail('Call smart contract resolved address failed')
+        throw ex
+      }
+    }
+
+    // Try to call a read only function on the resolved address
+    spinner = ora(
+      'Trying to call a read only function on the resolved address'
+    ).start()
+    const callReadOnlyData = {
+      fee: fromMAS(0.01),
+      targetAddress: resolvedAddress,
+      targetFunction: 'getBalance',
+      parameter: new Args().serialize(),
+    } as ICallData
+    try {
+      await web3Client.smartContracts().readSmartContract(callReadOnlyData)
+    } catch (ex) {
+      if (
+        ex.message.endsWith(
+          `The called address ${resolvedAddress} is not a smart contract address`
+        )
+      ) {
+        spinner.succeed('Read smart contract resolved address successfully')
+      } else {
+        spinner.fail('Read smart contract resolved address failed')
+        throw ex
+      }
+    }
+  } catch (ex) {
+    console.error(ex)
+    const msg = chalk.red(`Error = ${ex}`)
+    if (spinner) spinner.fail(msg)
+    process.exit(-1)
+  }
+})()

--- a/packages/massa-web3/examples/wallet/index.ts
+++ b/packages/massa-web3/examples/wallet/index.ts
@@ -117,7 +117,7 @@ const receiverPrivateKey = getEnvVariable('RECEIVER_PRIVATE_KEY')
     // send from base account to receiver
     const txId = await web3Client.wallet().sendTransaction({
       amount: fromMAS(1),
-      fee: 0n,
+      fee: fromMAS(0.01),
       recipientAddress: receiverAccount.address,
     } as ITransactionData)
     console.log('Money Transfer:: TxId ', txId[0])
@@ -164,7 +164,7 @@ const receiverPrivateKey = getEnvVariable('RECEIVER_PRIVATE_KEY')
     // sender buys some rolls
     const buyRollsTxId = await web3Client.wallet().buyRolls({
       amount: 2n,
-      fee: fromMAS(0),
+      fee: fromMAS(0.01),
     } as IRollsData)
     console.log('Buy Rolls Tx Id ', buyRollsTxId)
 

--- a/packages/massa-web3/src/interfaces/ICallData.ts
+++ b/packages/massa-web3/src/interfaces/ICallData.ts
@@ -11,7 +11,7 @@ import { Args } from '@massalabs/web3-utils'
  * @see fee of type `bigint` represents the transaction fee.
  * @see maxGas of type `bigint` represents the maximum amount of gas that the execution of the contract is allowed to cost.
  * @see coins of type `bigint` represents the extra coins in `nanoMassa` that are spent from the caller's balance and transferred to the target.
- * @see targetAddress of type `string` represents the target smart contract address.
+ * @see targetAddress of type `string` represents the target smart contract address or the MNS domain associated.
  * @see targetFunction of type `string` represents the target function name. No function is called if empty.
  * @see parameter of type `Array<number>` or an Args represents the parameters to pass to the target function.
  */

--- a/packages/massa-web3/src/interfaces/IClient.ts
+++ b/packages/massa-web3/src/interfaces/IClient.ts
@@ -4,6 +4,7 @@ import { IProvider } from './IProvider'
 import { IPublicApiClient } from './IPublicApiClient'
 import { ISmartContractsClient } from './ISmartContractsClient'
 import { IWalletClient } from './IWalletClient'
+import { MnsResolver } from '../web3/MnsResolver'
 
 /**
  * Represents the client object.
@@ -17,14 +18,18 @@ import { IWalletClient } from './IWalletClient'
  * @see publicApi() - A function that returns an instance of the public API client.
  * @see wallet() - A function that returns an instance of the wallet client.
  * @see smartContracts() - A function that returns an instance of the smart contracts client.
+ * @see mnsResolver() - A function that returns an instance of the MNS resolver.
  * @see setCustomProviders - A method for setting custom providers.
  * @see setNewDefaultProvider - A method for setting a new default provider.
+ * @see setNewMnsResolver - A method for setting a new MNS resolver.
  */
 export interface IClient {
   privateApi(): IPrivateApiClient
   publicApi(): IPublicApiClient
   wallet(): IWalletClient
   smartContracts(): ISmartContractsClient
+  mnsResolver(): MnsResolver
   setCustomProviders(providers: Array<IProvider>): void
   setNewDefaultProvider(provider: DefaultProviderUrls): void
+  setNewMnsResolver(contractAddress: string): void
 }

--- a/packages/massa-web3/src/interfaces/IContractData.ts
+++ b/packages/massa-web3/src/interfaces/IContractData.ts
@@ -12,7 +12,7 @@
  * @see maxCoins of type `bigint` represents maximum amount of coins allowed to be spent by the execution
  * @see contractDataText of type `string | undefined` represents the contract's data as string (optional).
  * @see contractDataBinary of type `Uint8Array | undefined` represents the contract's data as bytecode (optional).
- * @see address of type `string | undefined` represents the smart contract address (optional).
+ * @see address of type `string | undefined` represents the smart contract address (optional) or the MNS domain associated.
  * @see datastore of type `Map<Uint8Array, Uint8Array> | undefined` represents the smart contract's operational storage data (optional).
  */
 export interface IContractData {

--- a/packages/massa-web3/src/interfaces/IEventFilter.ts
+++ b/packages/massa-web3/src/interfaces/IEventFilter.ts
@@ -5,8 +5,8 @@ import { ISlot } from '@massalabs/web3-utils'
  *
  * @see start of type `ISlot` represents the start of the time interval (can be null).
  * @see end of type `ISlot` represents the end of the time interval (can be null).
- * @see emitter_address of type `string` represents the address that emitted the event (can be null).
- * @see original_caller_address of type `string` represents the operation id that generated the event (can be null).
+ * @see emitter_address of type `string` represents the address that emitted the event (can be null) or the MNS domain associated.
+ * @see original_caller_address of type `string` represents the operation id that generated the event (can be null) or the MNS domain associated.
  * @see is_final of type `boolean` to filter final events (true), candidate events (false) or both (null).
  */
 export interface IEventFilter {

--- a/packages/massa-web3/src/interfaces/IMnsResolver.ts
+++ b/packages/massa-web3/src/interfaces/IMnsResolver.ts
@@ -1,0 +1,15 @@
+/**
+ * Represents the MNS resolver object.
+ *
+ * @remarks
+ * This interface is used to resolve domain name to addresses. It also provides methods for setting
+ * custom mns resolver instead of the default one provided for MAINNET and BUILDNET.
+ *
+ * @see resolve - A function that returns the address of the domain if it exists or throws an error if it does not.
+ * @see setMnsResolver - A method for setting a custom mns resolver.
+ */
+
+export interface IMnsResolver {
+  resolve(domain: string): Promise<string>
+  setMnsResolver(contractAddress: string): void
+}

--- a/packages/massa-web3/src/interfaces/IMnsResolver.ts
+++ b/packages/massa-web3/src/interfaces/IMnsResolver.ts
@@ -11,5 +11,6 @@
 
 export interface IMnsResolver {
   resolve(domain: string): Promise<string>
+  getMnsResolverAddress(): string | undefined
   setMnsResolver(contractAddress: string): void
 }

--- a/packages/massa-web3/src/interfaces/IReadData.ts
+++ b/packages/massa-web3/src/interfaces/IReadData.ts
@@ -4,7 +4,7 @@ import { Args } from '@massalabs/web3-utils'
  * Represents the data of a read operation.
  *
  * @see maxGas - The maximum amount of gas that the execution of the contract is allowed to cost.
- * @see targetAddress - Target smart contract address
+ * @see targetAddress - Target smart contract address or the mns associated
  * @see targetFunction - Target function name. No function is called if empty.
  * @see parameter - Parameter to pass to the target function
  * @see callerAddress - Caller address

--- a/packages/massa-web3/src/web3/Client.ts
+++ b/packages/massa-web3/src/web3/Client.ts
@@ -7,11 +7,13 @@ import { IProvider, ProviderType } from '../interfaces/IProvider'
 import { IClient } from '../interfaces/IClient'
 import { IBaseAccount } from '../interfaces/IBaseAccount'
 import { DefaultProviderUrls } from '@massalabs/web3-utils'
+import { MnsResolver } from './MnsResolver'
 
 /**
  * Massa Web3 Client object wraps all public, private, wallet and smart-contracts-related functionalities.
  */
 export class Client implements IClient {
+  private mnsResolver: MnsResolver
   private publicApiClient: PublicApiClient
   private privateApiClient: PrivateApiClient
   private walletClient: WalletClient
@@ -22,12 +24,16 @@ export class Client implements IClient {
    *
    * @param clientConfig - client configuration object.
    * @param baseAccount - base account to use for signing transactions (optional).
+   * @param publicApiClient - public api client to use (optional).
+   * @param mnsResolverAddress - MNS resolver address to use (optional).
    */
   public constructor(
     private clientConfig: IClientConfig,
     baseAccount?: IBaseAccount,
-    publicApiClient?: PublicApiClient
+    publicApiClient?: PublicApiClient,
+    mnsResolverAddress?: string
   ) {
+    this.mnsResolver = new MnsResolver(clientConfig, mnsResolverAddress)
     this.publicApiClient = publicApiClient || new PublicApiClient(clientConfig)
     this.privateApiClient = new PrivateApiClient(clientConfig)
     this.walletClient = new WalletClient(
@@ -38,7 +44,8 @@ export class Client implements IClient {
     this.smartContractsClient = new SmartContractsClient(
       clientConfig,
       this.publicApiClient,
-      this.walletClient
+      this.walletClient,
+      this.mnsResolver
     )
 
     // subclients

--- a/packages/massa-web3/src/web3/Client.ts
+++ b/packages/massa-web3/src/web3/Client.ts
@@ -13,7 +13,7 @@ import { MnsResolver } from './MnsResolver'
  * Massa Web3 Client object wraps all public, private, wallet and smart-contracts-related functionalities.
  */
 export class Client implements IClient {
-  private mnsResolver: MnsResolver
+  private mnsResolverVar: MnsResolver
   private publicApiClient: PublicApiClient
   private privateApiClient: PrivateApiClient
   private walletClient: WalletClient
@@ -33,19 +33,20 @@ export class Client implements IClient {
     publicApiClient?: PublicApiClient,
     mnsResolverAddress?: string
   ) {
-    this.mnsResolver = new MnsResolver(clientConfig, mnsResolverAddress)
+    this.mnsResolverVar = new MnsResolver(clientConfig, mnsResolverAddress)
     this.publicApiClient = publicApiClient || new PublicApiClient(clientConfig)
     this.privateApiClient = new PrivateApiClient(clientConfig)
     this.walletClient = new WalletClient(
       clientConfig,
       this.publicApiClient,
+      this.mnsResolverVar,
       baseAccount
     )
     this.smartContractsClient = new SmartContractsClient(
       clientConfig,
       this.publicApiClient,
       this.walletClient,
-      this.mnsResolver
+      this.mnsResolverVar
     )
 
     // subclients
@@ -53,6 +54,7 @@ export class Client implements IClient {
     this.publicApi = this.publicApi.bind(this)
     this.wallet = this.wallet.bind(this)
     this.smartContracts = this.smartContracts.bind(this)
+    this.mnsResolver = this.mnsResolver.bind(this)
     // setters
     this.setCustomProviders = this.setCustomProviders.bind(this)
     this.setNewDefaultProvider = this.setNewDefaultProvider.bind(this)
@@ -96,6 +98,15 @@ export class Client implements IClient {
    */
   public smartContracts(): SmartContractsClient {
     return this.smartContractsClient
+  }
+
+  /**
+   * Get the MNS resolver object.
+   *
+   * @returns MnsResolver object.
+   */
+  public mnsResolver(): MnsResolver {
+    return this.mnsResolverVar
   }
 
   /**
@@ -161,5 +172,14 @@ export class Client implements IClient {
     this.privateApiClient.setProviders(providers)
     this.walletClient.setProviders(providers)
     this.smartContractsClient.setProviders(providers)
+  }
+
+  /**
+   * Set a new MNS resolver address.
+   *
+   * @param contractAddress - The new MNS resolver contract address.
+   */
+  public setNewMnsResolver(contractAddress: string): void {
+    this.mnsResolverVar.setMnsResolver(contractAddress)
   }
 }

--- a/packages/massa-web3/src/web3/ClientFactory.ts
+++ b/packages/massa-web3/src/web3/ClientFactory.ts
@@ -9,7 +9,10 @@ import {
 import { Web3Account } from './accounts/Web3Account'
 import { PublicApiClient } from './PublicApiClient'
 import { WalletProviderAccount } from './accounts/WalletProviderAccount'
-import { DefaultProviderUrls } from '@massalabs/web3-utils'
+import {
+  DefaultProviderUrls,
+  CHAIN_ID_DNS_ADDRESS_MAP,
+} from '@massalabs/web3-utils'
 
 /**
  * Massa Web3 ClientFactory class allows you to easily initialize a client to
@@ -77,7 +80,8 @@ export class ClientFactory {
         providers,
       } as IClientConfig,
       account,
-      publicApi
+      publicApi,
+      CHAIN_ID_DNS_ADDRESS_MAP[chainId.toString()]
     )
     return client
   }
@@ -110,7 +114,12 @@ export class ClientFactory {
     if (baseAccount) {
       account = new Web3Account(baseAccount, publicApi, chainId)
     }
-    const client: Client = new Client(clientConfig, account, publicApi)
+    const client: Client = new Client(
+      clientConfig,
+      account,
+      publicApi,
+      CHAIN_ID_DNS_ADDRESS_MAP[chainId.toString()]
+    )
     return client
   }
 
@@ -142,7 +151,9 @@ export class ClientFactory {
         retryStrategyOn,
         providers,
       },
-      new WalletProviderAccount(baseAccount)
+      new WalletProviderAccount(baseAccount),
+      undefined,
+      CHAIN_ID_DNS_ADDRESS_MAP[provider.getChainId().toString()]
     )
 
     return client

--- a/packages/massa-web3/src/web3/MnsResolver.ts
+++ b/packages/massa-web3/src/web3/MnsResolver.ts
@@ -42,14 +42,17 @@ export class MnsResolver extends BaseClient implements IMnsResolver {
         'Invalid domain name. Domain name should end with ".massa"'
       )
     }
+
+    // remove .massa from domain
+    domain = domain.slice(0, -6)
     const data = {
-      max_gas: MAX_GAS_CALL,
+      max_gas: Number(MAX_GAS_CALL),
       target_address: this.contractResolver,
       target_function: 'dnsResolve',
       parameter: new Args().addString(domain).serialize(),
       caller_address: this.contractResolver,
-      coins: 0,
-      fee: 0,
+      coins: undefined,
+      fee: undefined,
     }
 
     // returns operation ids
@@ -84,5 +87,14 @@ export class MnsResolver extends BaseClient implements IMnsResolver {
    */
   public setMnsResolver(contractAddress: string): void {
     this.contractResolver = contractAddress
+  }
+
+  /**
+   * Get the MNS resolver contract address.
+   *
+   * @returns The MNS resolver contract address.
+   */
+  public getMnsResolverAddress(): string {
+    return this.contractResolver
   }
 }

--- a/packages/massa-web3/src/web3/MnsResolver.ts
+++ b/packages/massa-web3/src/web3/MnsResolver.ts
@@ -1,0 +1,88 @@
+import {
+  Args,
+  IContractReadOperationData,
+  MAX_GAS_CALL,
+  bytesToStr,
+} from '@massalabs/web3-utils'
+import { IClientConfig } from '../interfaces/IClientConfig'
+import { IMnsResolver } from '../interfaces/IMnsResolver'
+import { BaseClient } from './BaseClient'
+import { JSON_RPC_REQUEST_METHOD } from '../interfaces/JsonRpcMethods'
+import { trySafeExecute } from '../utils/retryExecuteFunction'
+
+export class MnsResolver extends BaseClient implements IMnsResolver {
+  private contractResolver?: string
+
+  /**
+   * Constructor of the MnsResolver class.
+   *
+   * @param clientConfig - client configuration object.
+   * @param dnsAddress - DNS address to use for resolving MNS records.
+   */
+  public constructor(clientConfig: IClientConfig, dnsAddress?: string) {
+    super(clientConfig)
+    this.contractResolver = dnsAddress
+  }
+
+  /**
+   * Resolves the domain to an address.
+   *
+   * @param domain - Domain to resolve.
+   *
+   * @returns A promise that resolves to the address of the domain if it exists or throws an error if it does not.
+   */
+  public async resolve(domain: string): Promise<string> {
+    if (!this.contractResolver) {
+      throw new Error(
+        'MNS resolver contract address is not set. Use setMnsResolver method to set the contract address.'
+      )
+    }
+    if (!domain || !domain.endsWith('.massa')) {
+      throw new Error(
+        'Invalid domain name. Domain name should end with ".massa"'
+      )
+    }
+    const data = {
+      max_gas: MAX_GAS_CALL,
+      target_address: this.contractResolver,
+      target_function: 'dnsResolve',
+      parameter: new Args().addString(domain).serialize(),
+      caller_address: this.contractResolver,
+      coins: 0,
+      fee: 0,
+    }
+
+    // returns operation ids
+    const jsonRpcRequestMethod = JSON_RPC_REQUEST_METHOD.EXECUTE_READ_ONLY_CALL
+    let jsonRpcCallResult: Array<IContractReadOperationData> = []
+    if (this.clientConfig.retryStrategyOn) {
+      jsonRpcCallResult = await trySafeExecute<
+        Array<IContractReadOperationData>
+      >(this.sendJsonRPCRequest, [jsonRpcRequestMethod, [[data]]])
+    } else {
+      jsonRpcCallResult = await this.sendJsonRPCRequest(jsonRpcRequestMethod, [
+        [data],
+      ])
+    }
+
+    if (jsonRpcCallResult.length <= 0) {
+      throw new Error(
+        'Read operation bad response. No results array in json rpc response. Inspect smart contract'
+      )
+    }
+    if (jsonRpcCallResult[0].result.Error) {
+      throw new Error(jsonRpcCallResult[0].result.Error)
+    }
+
+    return bytesToStr(jsonRpcCallResult[0].result.Ok)
+  }
+
+  /**
+   * Sets the MNS resolver contract address.
+   *
+   * @param contractAddress - Contract address to use for resolving MNS records.
+   */
+  public setMnsResolver(contractAddress: string): void {
+    this.contractResolver = contractAddress
+  }
+}

--- a/packages/massa-web3/test/web3/smartContractsClient.spec.ts
+++ b/packages/massa-web3/test/web3/smartContractsClient.spec.ts
@@ -29,6 +29,7 @@ import {
 } from './mockData'
 import { IExecuteReadOnlyResponse } from '../../src/interfaces/IExecuteReadOnlyResponse'
 import { Web3Account } from '../../src/web3/accounts/Web3Account'
+import { MnsResolver } from '../../src/web3/MnsResolver'
 
 // Mock to not wait for the timeout to finish
 jest.mock('../../src/utils/time', () => {
@@ -43,9 +44,11 @@ describe('SmartContractsClient', () => {
   let mockPublicApiClient: PublicApiClient
   let mockWalletClient: WalletClient
   let mockDeployerAccount: Web3Account
+  let mockMnsResolver: MnsResolver
 
   beforeEach(() => {
     // Initialize the mock objects
+    mockMnsResolver = new MnsResolver(mockClientConfig)
     mockPublicApiClient = new PublicApiClient(mockClientConfig)
     mockDeployerAccount = new Web3Account(
       importedMockDeployerAccount,
@@ -55,12 +58,14 @@ describe('SmartContractsClient', () => {
     mockWalletClient = new WalletClient(
       mockClientConfig,
       mockPublicApiClient,
+      mockMnsResolver,
       mockDeployerAccount
     )
     smartContractsClient = new SmartContractsClient(
       mockClientConfig,
       mockPublicApiClient,
-      mockWalletClient
+      mockWalletClient,
+      mockMnsResolver
     )
 
     // Mock getOperations

--- a/packages/web3-utils/src/constants.ts
+++ b/packages/web3-utils/src/constants.ts
@@ -76,3 +76,10 @@ export const CHAIN_ID_RPC_URL_MAP = {
   [BUILDNET_CHAIN_ID.toString()]: DefaultProviderUrls.BUILDNET,
   [SANDBOX_CHAIN_ID.toString()]: DefaultProviderUrls.LOCALNET,
 } as const // type is inferred as the specific, unchangeable structure
+
+export const CHAIN_ID_DNS_ADDRESS_MAP = {
+  [MAINNET_CHAIN_ID.toString()]:
+    'AS12mdKsjAqcWC5DjabWZp7tG9s5wgkrwDGDuh6xUCSc53SrmfY9r',
+  [BUILDNET_CHAIN_ID.toString()]:
+    'AS12qKAVjU1nr66JSkQ6N4Lqu4iwuVc6rAbRTrxFoynPrPdP1sj3G',
+} as const // type is inferred as the specific, unchangeable structure


### PR DESCRIPTION
This PR adds to our tooling the usage of the Massa Name Service as asked in the [RFP](https://github.com/massalabs/massa/discussions/4057).

The domain name resolver is set by default for buildnet and mainnet but can be also override by hand.

The domain resolution is used for any address field in the smart contract client and send transaction

Everything is tested through an example (all examples has been updated to work correctly)
