### PR TITLE
refactor openRPC spec

### DIFF
--- a/.github/workflows/coverage-v2.yml
+++ b/.github/workflows/coverage-v2.yml
@@ -19,3 +19,4 @@ jobs:
                 prnumber: ${{ steps.findPr.outputs.number }}
                 working-directory: ./
                 test-script: npm test
+                annotations: none

--- a/open_rpc/massa.api.json
+++ b/open_rpc/massa.api.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.4",
     "info": {
         "title": "Massa OpenRPC Specification",
-        "version": "MAIN.2.1",
+        "version": "MAIN.2.4",
         "description": "Massa OpenRPC Specification document. Find more information on https://docs.massa.net/docs/build/api/jsonrpc",
         "termsOfService": "https://open-rpc.org",
         "contact": {
@@ -136,6 +136,7 @@
                     "name": "addressFilter",
                     "description": "Need to provide at least one valid address filter",
                     "schema": {
+                        "title": "Address list",
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/AddressFilter"
@@ -146,10 +147,10 @@
             ],
             "result": {
                 "schema": {
+                    "title": "Bytecode list",
                     "type": "array",
                     "items": {
-                        "type": "string",
-                        "format": "byte"
+                        "$ref": "#/components/schemas/Bytes"
                     }
                 },
                 "name": "Addresses bytecode array"
@@ -167,7 +168,7 @@
             ],
             "params": [
                 {
-                    "name": "blockId",
+                    "name": "blockIds",
                     "description": "Need to provide at least one valid block id",
                     "schema": {
                         "type": "array",
@@ -204,7 +205,6 @@
                     "name": "slot",
                     "description": "Slot of the block",
                     "schema": {
-                        "type": "object",
                         "$ref": "#/components/schemas/Slot"
                     },
                     "required": true
@@ -323,7 +323,7 @@
                     "schema": {
                         "type": "array",
                         "items": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/EndorsementId"
                         }
                     },
                     "required": true
@@ -359,6 +359,7 @@
             ],
             "result": {
                 "schema": {
+                    "title": "Output events",
                     "type": "array",
                     "items": {
                         "$ref": "#/components/schemas/SCOutputEvent"
@@ -421,7 +422,7 @@
                     "schema": {
                         "type": "array",
                         "items": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/OperationId"
                         }
                     },
                     "required": true
@@ -528,7 +529,6 @@
                 "schema": {
                     "type": "array",
                     "items": {
-                        "description": "Address",
                         "$ref": "#/components/schemas/Address"
                     }
                 },
@@ -551,11 +551,7 @@
                     "name": "ip",
                     "description": "The strings must be IP addresses",
                     "schema": {
-                        "type": "array",
-                        "items": {
-                            "description": "Ip address",
-                            "type": "string"
-                        }
+                        "$ref": "#/components/schemas/IpAddressList"
                     },
                     "required": true
                 }
@@ -581,11 +577,7 @@
                     "name": "ip",
                     "description": "The strings must be IP addresses",
                     "schema": {
-                        "type": "array",
-                        "items": {
-                            "description": "Ip address",
-                            "type": "string"
-                        }
+                        "$ref": "#/components/schemas/IpAddressList"
                     },
                     "required": true
                 }
@@ -611,11 +603,7 @@
                     "name": "ip",
                     "description": "The strings must be IP addresses",
                     "schema": {
-                        "type": "array",
-                        "items": {
-                            "description": "Ip address",
-                            "type": "string"
-                        }
+                        "$ref": "#/components/schemas/IpAddressList"
                     },
                     "required": true
                 }
@@ -670,10 +658,7 @@
                     "name": "ip",
                     "description": "The strings are IP addresses.",
                     "schema": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "$ref": "#/components/schemas/IpAddressList"
                     },
                     "required": true
                 }
@@ -699,11 +684,7 @@
                 "name": "ip",
                 "description": "The strings must be IP addresses",
                 "schema": {
-                    "type": "array",
-                    "items": {
-                        "description": "Ip address",
-                        "$ref": "#/components/schemas/IpAddress"
-                    }
+                    "$ref": "#/components/schemas/IpAddressList"
                 }
             },
             "name": "node_bootstrap_blacklist",
@@ -722,11 +703,7 @@
                 "name": "ip",
                 "description": "The strings must be IP addresses",
                 "schema": {
-                    "type": "array",
-                    "items": {
-                        "description": "Ip address",
-                        "$ref": "#/components/schemas/IpAddress"
-                    }
+                    "$ref": "#/components/schemas/IpAddressList"
                 }
             },
             "name": "node_bootstrap_whitelist",
@@ -762,11 +739,7 @@
                 "name": "ip",
                 "description": "The strings must be IP addresses",
                 "schema": {
-                    "type": "array",
-                    "items": {
-                        "description": "Ip address",
-                        "$ref": "#/components/schemas/IpAddress"
-                    }
+                    "$ref": "#/components/schemas/IpAddressList"
                 }
             },
             "name": "node_peers_whitelist",
@@ -785,11 +758,7 @@
                     "name": "ip",
                     "description": "The strings must be IP addresses",
                     "schema": {
-                        "type": "array",
-                        "items": {
-                            "description": "Ip address",
-                            "type": "string"
-                        }
+                        "$ref": "#/components/schemas/IpAddressList"
                     },
                     "required": true
                 }
@@ -815,11 +784,7 @@
                     "name": "ip",
                     "description": "The strings must be IP addresses",
                     "schema": {
-                        "type": "array",
-                        "items": {
-                            "description": "Ip address",
-                            "type": "string"
-                        }
+                        "$ref": "#/components/schemas/IpAddressList"
                     },
                     "required": true
                 }
@@ -845,11 +810,7 @@
                     "name": "ip",
                     "description": "The strings must be IP addresses",
                     "schema": {
-                        "type": "array",
-                        "items": {
-                            "description": "Ip address",
-                            "type": "string"
-                        }
+                        "$ref": "#/components/schemas/IpAddressList"
                     },
                     "required": true
                 }
@@ -875,11 +836,7 @@
                     "name": "ip",
                     "description": "The strings must be IP addresses",
                     "schema": {
-                        "type": "array",
-                        "items": {
-                            "description": "Ip address",
-                            "type": "string"
-                        }
+                        "$ref": "#/components/schemas/IpAddressList"
                     },
                     "required": true
                 }
@@ -907,7 +864,6 @@
                     "schema": {
                         "type": "array",
                         "items": {
-                            "description": "Address",
                             "$ref": "#/components/schemas/Address"
                         }
                     },
@@ -935,8 +891,7 @@
                     "name": "message",
                     "description": "Message to be signed in byte array",
                     "schema": {
-                        "format": "byte",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Bytes"
                     },
                     "required": true
                 }
@@ -982,8 +937,7 @@
                     "schema": {
                         "type": "array",
                         "items": {
-                            "description": "Ip address",
-                            "type": "string"
+                            "$ref": "#/components/schemas/IpAddress"
                         }
                     },
                     "required": true
@@ -1010,11 +964,7 @@
                     "name": "ip",
                     "description": "The strings are IP addresses.",
                     "schema": {
-                        "type": "array",
-                        "items": {
-                            "description": "Ip address",
-                            "type": "string"
-                        }
+                        "$ref": "#/components/schemas/IpAddressList"
                     },
                     "required": true
                 }
@@ -1040,11 +990,7 @@
                     "name": "ip",
                     "description": "The strings must be IP addresses",
                     "schema": {
-                        "type": "array",
-                        "items": {
-                            "description": "ip address",
-                            "type": "string"
-                        }
+                        "$ref": "#/components/schemas/IpAddressList"
                     },
                     "required": true
                 }
@@ -1424,18 +1370,56 @@
                 "description": "Address",
                 "type": "string"
             },
+            "AddressOption": {
+                "title": "Address Option",
+                "description": "Address",
+                "oneOf": [
+                    {
+                        "type": "null"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Address"
+                    }
+                ]
+            },
+            "SCCallParams": {
+                "title": "SC call params",
+                "description": "Serialized SC call params",
+                "type": "array",
+                "items": {
+                    "type": "integer"
+                }
+            },
+            "Bytes": {
+                "title": "Bytes",
+                "description": "Byte array",
+                "type": "array",
+                "items": {
+                    "type": "integer"
+                }
+            },
+            "BytesOption": {
+                "title": "Bytes Option",
+                "description": "Byte array",
+                "oneOf": [
+                    {
+                        "type": "null"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Bytes"
+                    }
+                ]
+            },
             "AddressFilter": {
                 "title": "AddressFilter",
                 "description": "Address filter",
                 "type": "object",
                 "properties": {
                     "address": {
-                        "$ref": "#/components/schemas/Address",
-                        "description": "The address"
+                        "$ref": "#/components/schemas/Address"
                     },
                     "is_final": {
-                        "type": "boolean",
-                        "description": "true means final, false means candidate"
+                        "$ref": "#/components/schemas/IsFinal"
                     }
                 },
                 "additionalProperties": false
@@ -1462,47 +1446,41 @@
                 "type": "object",
                 "properties": {
                     "address": {
-                        "$ref": "#/components/schemas/Address",
-                        "description": "The address"
+                        "$ref": "#/components/schemas/Address"
                     },
                     "thread": {
                         "description": "The thread the address belongs to",
-                        "type": "number"
+                        "$ref": "#/components/schemas/Thread"
                     },
                     "final_balance": {
                         "description": "The final balance",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Amount"
                     },
                     "final_roll_count": {
                         "description": "The final roll count",
-                        "type": "number"
+                        "$ref": "#/components/schemas/RollAmount"
                     },
                     "final_datastore_keys": {
                         "description": "The final datastore keys",
+                        "title": "Datastore Keys",
                         "type": "array",
                         "items": {
-                            "type": "array",
-                            "items": {
-                                "type": "number"
-                            }
+                            "$ref": "#/components/schemas/Bytes"
                         }
                     },
                     "candidate_balance": {
-                        "description": "The candidate balance",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Amount"
                     },
                     "candidate_roll_count": {
                         "description": "The candidate roll count",
-                        "type": "number"
+                        "$ref": "#/components/schemas/RollAmount"
                     },
                     "candidate_datastore_keys": {
                         "description": "The candidate datastore keys",
+                        "title": "Datastore Keys",
                         "type": "array",
                         "items": {
-                            "type": "array",
-                            "items": {
-                                "type": "number"
-                            }
+                            "$ref": "#/components/schemas/Bytes"
                         }
                     },
                     "deferred_credits": {
@@ -1512,11 +1490,10 @@
                             "type": "object",
                             "properties": {
                                 "slot": {
-                                    "$ref": "#/components/schemas/Slot",
-                                    "type": "object"
+                                    "$ref": "#/components/schemas/Slot"
                                 },
                                 "amount": {
-                                    "type": "string"
+                                    "$ref": "#/components/schemas/Amount"
                                 }
                             }
                         },
@@ -1526,8 +1503,7 @@
                         "description": "The next block draws",
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/Slot",
-                            "type": "object"
+                            "$ref": "#/components/schemas/Slot"
                         }
                     },
                     "next_endorsement_draws": {
@@ -1537,8 +1513,7 @@
                             "type": "object",
                             "properties": {
                                 "slot": {
-                                    "$ref": "#/components/schemas/Slot",
-                                    "type": "object"
+                                    "$ref": "#/components/schemas/Slot"
                                 },
                                 "index": {
                                     "type": "number"
@@ -1550,8 +1525,7 @@
                         "description": "BlockIds of created blocks",
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/BlockId",
-                            "type": "string"
+                            "$ref": "#/components/schemas/BlockId"
                         },
                         "minItems": 0
                     },
@@ -1559,8 +1533,7 @@
                         "description": "OperationIds of created operations",
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/OperationId",
-                            "type": "string"
+                            "$ref": "#/components/schemas/OperationId"
                         },
                         "minItems": 0
                     },
@@ -1568,8 +1541,7 @@
                         "description": "EndorsementIds of created endorsements",
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/EndorsementId",
-                            "type": "string"
+                            "$ref": "#/components/schemas/EndorsementId"
                         },
                         "minItems": 0
                     },
@@ -1577,8 +1549,7 @@
                         "description": "Cycle infos",
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/ExecutionAddressCycleInfo",
-                            "type": "object"
+                            "$ref": "#/components/schemas/ExecutionAddressCycleInfo"
                         }
                     }
                 },
@@ -1606,16 +1577,13 @@
                 "type": "object",
                 "properties": {
                     "candidate_balance": {
-                        "description": "Represent an Amount in coins",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Amount"
                     },
                     "final_balance": {
-                        "description": "Represent an Amount in coins",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Amount"
                     },
                     "locked_balance": {
-                        "description": "Represent an Amount in coins",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Amount"
                     }
                 },
                 "additionalProperties": false
@@ -1636,7 +1604,7 @@
                         "description": "Operations",
                         "type": "array",
                         "items": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/OperationId"
                         }
                     }
                 },
@@ -1655,7 +1623,7 @@
                 "type": "object",
                 "properties": {
                     "id": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/BlockId"
                     },
                     "content": {
                         "$ref": "#/components/schemas/BlockInfoContent"
@@ -1675,19 +1643,16 @@
                 "properties": {
                     "is_final": {
                         "description": "true if final",
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsFinal"
                     },
                     "is_candidate": {
-                        "description": "true if candidate",
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsCandidate"
                     },
                     "is_discarded": {
-                        "description": "true if discarded",
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsDiscarded"
                     },
                     "is_in_blockclique": {
-                        "description": "true if in the greatest clique",
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsInBlockClique"
                     },
                     "block": {
                         "$ref": "#/components/schemas/Block",
@@ -1707,7 +1672,7 @@
                             "$ref": "#/components/schemas/BlockId"
                         },
                         "period": {
-                            "type": "number"
+                            "$ref": "#/components/schemas/Period"
                         }
                     }
                 },
@@ -1717,8 +1682,8 @@
                 }
             },
             "CallSC": {
-                "title": "CallSC",
-                "description": "Call Smart Contract",
+                "title": "CallSC Receipt",
+                "description": "CallSC operation receipt",
                 "required": [
                     "max_gas",
                     "param",
@@ -1729,23 +1694,21 @@
                 "type": "object",
                 "properties": {
                     "target_addr": {
-                        "$ref": "#/components/schemas/Address",
-                        "description": "Address"
+                        "$ref": "#/components/schemas/Address"
                     },
                     "target_func": {
-                        "description": "Function name",
+                        "description": "Contract Function name to call",
+                        "title": "Function name",
                         "type": "string"
                     },
                     "param": {
-                        "description": "Parameter to pass to the function",
-                        "type": "string"
+                        "$ref": "#/components/schemas/SCCallParams"
                     },
                     "max_gas": {
-                        "type": "number"
+                        "$ref": "#/components/schemas/GasAmount"
                     },
                     "coins": {
-                        "description": "Amount",
-                        "type": "number"
+                        "$ref": "#/components/schemas/Amount"
                     }
                 },
                 "additionalProperties": false
@@ -1795,8 +1758,7 @@
                 "type": "object",
                 "properties": {
                     "block_reward": {
-                        "description": "Represent an Amount in coins",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Amount"
                     },
                     "delta_f0": {
                         "description": "Used to compute finality threshold",
@@ -1830,8 +1792,7 @@
                         "type": "number"
                     },
                     "roll_price": {
-                        "description": "Represent an Amount in coins",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Amount"
                     },
                     "t0": {
                         "description": "Time between the periods in the same thread.",
@@ -1855,7 +1816,7 @@
                             "type": "string"
                         },
                         "ip_address": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/IpAddress"
                         }
                     }
                 },
@@ -1897,24 +1858,14 @@
                 "additionalProperties": false
             },
             "DataStore": {
-                "title": "Datastore",
+                "title": "Datastore entry",
                 "description": "A tuple which contains (entry, bytes)",
-                "type": "object",
-                "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                        "entry": {
-                            "type": "array",
-                            "items": {
-                                "type": "integer"
-                            }
-                        },
-                        "bytes": {
-                            "type": "array",
-                            "items": {
-                                "type": "integer"
-                            }
-                        }
+                "type": "array",
+                "maxItems": 2,
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/components/schemas/Bytes"
                     }
                 },
                 "example": [
@@ -1933,22 +1884,6 @@
                     ]
                 ]
             },
-            "DataStoreEntry": {
-                "title": "DatastoreEntry",
-                "description": "Datastore entry",
-                "type": "object",
-                "properties": {
-                    "candidate_value": {
-                        "description": "",
-                        "type": "string"
-                    },
-                    "final_value": {
-                        "description": "",
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false
-            },
             "DatastoreEntryInput": {
                 "title": "DatastoreEntryInput",
                 "description": "",
@@ -1962,11 +1897,7 @@
                         "$ref": "#/components/schemas/Address"
                     },
                     "key": {
-                        "description": "",
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
+                        "$ref": "#/components/schemas/Bytes"
                     }
                 },
                 "additionalProperties": false
@@ -1982,31 +1913,12 @@
                 "properties": {
                     "candidate_value": {
                         "description": "The candidate datastore entry value bytes",
-                        "oneOf": [
-                            {
-                                "type": "array",
-                                "items": {
-                                    "type": "integer"
-                                }
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/BytesOption"
+
                     },
                     "final_value": {
                         "description": "The final datastore entry value bytes",
-                        "oneOf": [
-                            {
-                                "type": "array",
-                                "items": {
-                                    "type": "integer"
-                                }
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/BytesOption"
                     }
                 },
                 "additionalProperties": false
@@ -2025,10 +1937,10 @@
                 "type": "object",
                 "properties": {
                     "public_key": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/PublicKey"
                     },
                     "slot": {
-                        "type": "integer"
+                        "$ref": "#/components/schemas/Slot"
                     },
                     "index": {
                         "type": "integer"
@@ -2040,10 +1952,10 @@
                         "type": "string"
                     },
                     "signature_1": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/Signature"
                     },
                     "signature_2": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/Signature"
                     }
                 }
             },
@@ -2051,10 +1963,10 @@
                 "type": "object",
                 "properties": {
                     "public_key": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/PublicKey"
                     },
                     "slot": {
-                        "type": "integer"
+                        "$ref": "#/components/schemas/Slot"
                     },
                     "hash_1": {
                         "type": "string"
@@ -2063,10 +1975,10 @@
                         "type": "string"
                     },
                     "signature_1": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/Signature"
                     },
                     "signature_2": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/Signature"
                     }
                 }
             },
@@ -2093,7 +2005,7 @@
                         "$ref": "#/components/schemas/EndorsementId"
                     },
                     "signature": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/Signature"
                     }
                 },
                 "additionalProperties": false
@@ -2128,7 +2040,7 @@
                         "type": "number"
                     },
                     "active_cursor": {
-                        "descritpion": "active execution cursor slot",
+                        "description": "active execution cursor slot",
                         "$ref": "#/components/schemas/Slot"
                     },
                     "final_cursor": {
@@ -2208,28 +2120,10 @@
                         }
                     },
                     "is_final": {
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsFinal"
                     },
                     "endorsement": {
-                        "$ref": "#/components/schemas/Endorsement",
-                        "description": "Endorsement"
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ExecutedAt": {
-                "title": "ExecuteAt",
-                "required": [
-                    "period",
-                    "thread"
-                ],
-                "type": "object",
-                "properties": {
-                    "period": {
-                        "type": "number"
-                    },
-                    "thread": {
-                        "type": "number"
+                        "$ref": "#/components/schemas/Endorsement"
                     }
                 },
                 "additionalProperties": false
@@ -2246,12 +2140,13 @@
                 "type": "object",
                 "properties": {
                     "executed_at": {
-                        "$ref": "#/components/schemas/ExecutedAt"
+                        "$ref": "#/components/schemas/Slot"
                     },
                     "result": {
                         "$ref": "#/components/schemas/ReadOnlyResult"
                     },
                     "output_events": {
+                        "title": "Output events",
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/SCOutputEvent"
@@ -2259,7 +2154,7 @@
                     },
                     "gas_cost": {
                         "description": "The gas cost for the execution",
-                        "type": "number"
+                        "$ref": "#/components/schemas/GasAmount"
                     },
                     "state_changes": {
                         "$ref": "#/components/schemas/StateChanges"
@@ -2268,8 +2163,8 @@
                 "additionalProperties": false
             },
             "ExecuteSC": {
-                "title": "ExecuteSC",
-                "description": "Execute Smart Contract",
+                "title": "ExecuteSC Receipt",
+                "description": "Execute SC operation receipt",
                 "required": [
                     "data",
                     "max_gas",
@@ -2278,15 +2173,11 @@
                 "type": "object",
                 "properties": {
                     "data": {
-                        "description": "Vec of bytes to execute",
-                        "type": "array",
-                        "items": {
-                            "type": "number"
-                        }
+                        "$ref": "#/components/schemas/Bytes"
                     },
                     "max_gas": {
                         "description": "Maximum amount of gas that the execution of the contract is allowed to cost.",
-                        "type": "number"
+                        "$ref": "#/components/schemas/GasAmount"
                     },
                     "datastore": {
                         "$ref": "#/components/schemas/DataStore",
@@ -2309,7 +2200,7 @@
                         "type": "number"
                     },
                     "is_final": {
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsFinal"
                     },
                     "ok_count": {
                         "type": "number"
@@ -2323,7 +2214,7 @@
                                 "type": "null"
                             },
                             {
-                                "type": "number"
+                                "$ref": "#/components/schemas/RollAmount"
                             }
                         ]
                     }
@@ -2346,23 +2237,22 @@
                     },
                     "emitter_address": {
                         "description": "Optional emitter address",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Address"
                     },
                     "original_caller_address": {
                         "description": "Optional caller address",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Address"
                     },
                     "original_operation_id": {
-                        "description": "Optional operation id",
-                        "type": "string"
+                        "$ref": "#/components/schemas/OperationId"
                     },
                     "is_final": {
                         "description": "Optional filter to filter only candidate or final events",
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsFinal"
                     },
                     "is_error": {
                         "description": "Optional filter to retrieve events generated in a failed execution",
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsError"
                     }
                 },
                 "additionalProperties": false
@@ -2402,14 +2292,15 @@
                         "description": "When was it generated"
                     },
                     "block": {
-                        "$ref": "#/components/schemas/BlockId",
-                        "description": "Block Id"
+                        "$ref": "#/components/schemas/BlockId"
                     },
                     "read_only": {
+                        "title": "Is Readonly",
                         "description": "Wether the event was generated during  read only call",
                         "type": "boolean"
                     },
                     "call_stack": {
+                        "title": "Address stack",
                         "description": "Addresses, most recent at the end",
                         "type": "array",
                         "items": {
@@ -2417,6 +2308,7 @@
                         }
                     },
                     "index_in_slot": {
+                        "title": "Index in slot",
                         "description": "Index of the event in the slot",
                         "type": "number"
                     },
@@ -2426,11 +2318,11 @@
                     },
                     "is_final": {
                         "description": "Whether the event is final",
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsFinal"
                     },
                     "is_error": {
                         "description": "Whether the event was generated in a failed executed or not",
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsError"
                     }
                 },
                 "additionalProperties": false
@@ -2439,6 +2331,14 @@
                 "title": "IpAddress",
                 "description": "Ipv4 or Ipv6 address",
                 "type": "string"
+            },
+            "IpAddressList": {
+                "title": "IpAddress List",
+                "description": "Array of Ipv4 or Ipv6 address",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/IpAddress"
+                }
             },
             "FilledBlock": {
                 "title": "FilledBlock",
@@ -2453,6 +2353,7 @@
                         "description": "signed header"
                     },
                     "operations": {
+                        "title": "Operations",
                         "description": "Operations",
                         "type": "array",
                         "items": {
@@ -2470,7 +2371,7 @@
                 "type": "object",
                 "properties": {
                     "id": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/OperationId"
                     },
                     "content": {
                         "$ref": "#/components/schemas/FilledBlockInfoContent"
@@ -2490,15 +2391,13 @@
                 "properties": {
                     "is_final": {
                         "description": "true if final",
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsFinal"
                     },
                     "is_stale": {
-                        "description": "true if incompatible with a final block",
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsStale"
                     },
                     "is_in_blockclique": {
-                        "description": "true if in the greatest clique",
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsInBlockClique"
                     },
                     "block": {
                         "$ref": "#/components/schemas/FilledBlock",
@@ -2522,26 +2421,26 @@
                 "properties": {
                     "creator": {
                         "description": "Public key",
-                        "type": "string"
+                        "$ref": "#/components/schemas/PublicKey"
                     },
                     "id": {
                         "description": "Block Id",
-                        "type": "string"
+                        "$ref": "#/components/schemas/BlockId"
                     },
                     "is_final": {
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsFinal"
                     },
                     "is_in_blockclique": {
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsInBlockClique"
                     },
                     "is_stale": {
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsStale"
                     },
                     "parents": {
                         "description": "As many block Ids as there are threads",
                         "type": "array",
                         "items": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/BlockId"
                         }
                     },
                     "slot": {
@@ -2580,7 +2479,7 @@
                     "parents": {
                         "type": "array",
                         "items": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/BlockId"
                         }
                     },
                     "slot": {
@@ -2596,7 +2495,7 @@
                                     "$ref": "#/components/schemas/EndorsementContent"
                                 },
                                 "signature": {
-                                    "type": "string"
+                                    "$ref": "#/components/schemas/Signature"
                                 },
                                 "content_creator_pub_key": {
                                     "$ref": "#/components/schemas/PublicKey"
@@ -2630,15 +2529,11 @@
                 "type": "object",
                 "properties": {
                     "balance": {
-                        "description": "Represent an amount",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Amount"
                     },
                     "module": {
                         "description": "Stored bytecode",
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
+                        "$ref": "#/components/schemas/Bytes"
                     },
                     "datastore": {
                         "type": "array",
@@ -2757,7 +2652,7 @@
                                 "type": "null"
                             },
                             {
-                                "type": "string"
+                                "$ref": "#/components/schemas/IpAddress"
                             }
                         ]
                     },
@@ -2779,7 +2674,7 @@
                     },
                     "minimal_fees": {
                         "description": "Minimal fee",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Amount"
                     }
                 },
                 "additionalProperties": false
@@ -2795,12 +2690,12 @@
                 "type": "object",
                 "properties": {
                     "fee": {
-                        "description": "the fee they have decided for this operation",
-                        "type": "string"
+                        "description": "Operation fee",
+                        "$ref": "#/components/schemas/Amount"
                     },
                     "expire_period": {
                         "description": "after `expire_period` slot the operation won't be included in a block",
-                        "type": "number"
+                        "$ref": "#/components/schemas/Period"
                     },
                     "op": {
                         "$ref": "#/components/schemas/OperationType",
@@ -2813,6 +2708,63 @@
                 "title": "OperationId",
                 "description": "Operation id",
                 "type": "string"
+            },
+            "Amount": {
+                "title": "Amount",
+                "description": "MAS amount in float string",
+                "type": "string"
+            },
+            "AmountOption": {
+                "title": "Amount Option",
+                "description": "MAS amount in float string",
+                "oneOf": [
+                    {
+                        "type": "null"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Amount"
+                    }
+                ]
+            },
+            "IsFinal": {
+                "title": "Is final",
+                "description": "Operation is final",
+                "type": "boolean"
+            },
+            "IsError": {
+                "title": "Error",
+                "description": "Operation execution error",
+                "type": "boolean"
+            },
+            "IsStale": {
+                "title": "Stale",
+                "description": "true if incompatible with a final block",
+                "type": "boolean"
+            },
+            "IsInBlockClique": {
+                "title": "In Block Clique",
+                "description": "true if in the last clique",
+                "type": "boolean"
+            },
+            "IsCandidate": {
+                "title": "Is candidate",
+                "description": "true if candidate",
+                "type": "boolean"
+            },
+            "IsDiscarded": {
+                "title": "Is discarded",
+                "description": "true if discarded",
+                "type": "boolean"
+            },
+            "RollAmount": {
+                "title": "Roll Amount",
+                "description": "Amount of rolls",
+                "type": "integer"
+            },
+            "GasAmount": {
+                "title": "Gas Amount",
+                "description": "Amount of gas",
+                "type": "integer"
             },
             "OperationInfo": {
                 "title": "OperationInfo",
@@ -2828,8 +2780,7 @@
                 "type": "object",
                 "properties": {
                     "id": {
-                        "description": "Operation id",
-                        "type": "string"
+                        "$ref": "#/components/schemas/OperationId"
                     },
                     "in_blocks": {
                         "description": "Block ids\nThe operation appears in `in_blocks`\nIf it appears in multiple blocks, these blocks are in different cliques",
@@ -2844,22 +2795,22 @@
                     },
                     "is_operation_final": {
                         "description": "True if the operation is final (for example in a final block)",
+                        "title": "Is Final Operation",
                         "oneOf": [
                             {
                                 "type": "null"
                             },
                             {
-                                "type": "boolean"
+                                "$ref": "#/components/schemas/IsFinal"
                             }
                         ]
                     },
                     "thread": {
                         "description": "Thread in which the operation can be included",
-                        "type": "number"
+                        "$ref": "#/components/schemas/Thread"
                     },
                     "operation": {
-                        "$ref": "#/components/schemas/WrappedOperation",
-                        "description": "The operation itself"
+                        "$ref": "#/components/schemas/WrappedOperation"
                     },
                     "op_exec_status": {
                         "description": "true if the operation execution succeeded, false if failed, None means unknown",
@@ -2894,10 +2845,7 @@
                         "description": "The signature of the operation"
                     },
                     "serialized_content": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
+                        "$ref": "#/components/schemas/Bytes"
                     }
                 },
                 "additionalProperties": false
@@ -2992,7 +2940,7 @@
                         "type": "integer"
                     },
                     "is_final": {
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/IsFinal"
                     },
                     "nok_count": {
                         "type": "integer"
@@ -3018,12 +2966,10 @@
                 "type": "object",
                 "properties": {
                     "public_key": {
-                        "description": "public key",
-                        "type": "string"
+                        "$ref": "#/components/schemas/PublicKey"
                     },
                     "signature": {
-                        "description": "signature",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Signature"
                     }
                 },
                 "additionalProperties": false
@@ -3039,37 +2985,32 @@
                 "properties": {
                     "max_gas": {
                         "description": "Max available gas",
-                        "type": "number"
+                        "$ref": "#/components/schemas/GasAmount"
                     },
                     "bytecode": {
-                        "description": "Bytecode to execute",
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
+                        "$ref": "#/components/schemas/Bytes"
                     },
                     "address": {
-                        "$ref": "#/components/schemas/Address",
+                        "$ref": "#/components/schemas/AddressOption",
                         "description": "caller's address"
                     },
                     "operation_datastore": {
-                        "description": "An operation datastore",
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
-                    },
-                    "is_final": {
-                        "description": "Whether to start execution from final or active state",
-                        "type": "boolean"
-                    },
-                    "coins": {
-                        "description": "Amount in coins, optional",
-                        "type": "number"
+                        "description": "Operation datastore TO FIX",
+                        "title": "Operation datastore",
+                        "oneOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "integer"
+                                }
+                            }
+                        ]
                     },
                     "fee": {
-                        "description": "Fee, optional",
-                        "type": "number"
+                        "$ref": "#/components/schemas/AmountOption"
                     }
                 },
                 "additionalProperties": false
@@ -3090,55 +3031,29 @@
                 "properties": {
                     "max_gas": {
                         "description": "Max available gas",
-                        "type": "number"
+                        "$ref": "#/components/schemas/GasAmount"
                     },
                     "target_address": {
                         "description": "Target address",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Address"
                     },
                     "target_function": {
                         "description": "Target function",
+                        "title": "Target Function",
                         "type": "string"
                     },
                     "parameter": {
-                        "description": "Function parameter",
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
+                        "$ref": "#/components/schemas/SCCallParams"
                     },
                     "caller_address": {
                         "description": "Caller's address, optional",
-                        "oneOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/AddressOption"
                     },
                     "coins": {
-                        "description": "Amount in coins, optional",
-                        "oneOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/AmountOption"
                     },
                     "fee": {
-                        "description": "Fee, optional",
-                        "oneOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/AmountOption"
                     }
                 },
                 "additionalProperties": false
@@ -3150,11 +3065,7 @@
                 "properties": {
                     "Ok": {
                         "description": "Included in case of success. The result of the execution",
-                        "type": "array",
-                        "items": {
-                            "format": "byte",
-                            "type": "string"
-                        }
+                        "$ref": "#/components/schemas/Bytes"
                     },
                     "Error": {
                         "description": "Included in case of error. The error message",
@@ -3172,22 +3083,21 @@
                 "type": "object",
                 "properties": {
                     "roll_count": {
-                        "type": "integer"
+                        "$ref": "#/components/schemas/RollAmount"
                     }
                 },
                 "additionalProperties": false
             },
             "RollBuy": {
-                "title": "RollBuy",
-                "description": "the sender buys `roll_count` rolls. Roll price is defined in configuration",
+                "title": "RollBuy Receipt",
+                "description": "Buy roll operation receipt",
                 "required": [
                     "roll_count"
                 ],
                 "type": "object",
                 "properties": {
                     "roll_count": {
-                        "description": "roll count",
-                        "type": "number"
+                        "$ref": "#/components/schemas/RollAmount"
                     }
                 },
                 "additionalProperties": false
@@ -3202,28 +3112,27 @@
                 "type": "object",
                 "properties": {
                     "active_rolls": {
-                        "type": "integer"
+                        "$ref": "#/components/schemas/RollAmount"
                     },
                     "candidate_rolls": {
-                        "type": "integer"
+                        "$ref": "#/components/schemas/RollAmount"
                     },
                     "final_rolls": {
-                        "type": "integer"
+                        "$ref": "#/components/schemas/RollAmount"
                     }
                 },
                 "additionalProperties": false
             },
             "RollSell": {
-                "title": "RollSell",
-                "description": "the sender sells `roll_count` rolls. Roll price is defined in configuration",
+                "title": "RollSell Receipt",
+                "description": "RollSell operation receipt",
                 "required": [
                     "roll_count"
                 ],
                 "type": "object",
                 "properties": {
                     "roll_count": {
-                        "description": "roll count",
-                        "type": "number"
+                        "$ref": "#/components/schemas/RollAmount"
                     }
                 },
                 "additionalProperties": false
@@ -3242,8 +3151,7 @@
                         "$ref": "#/components/schemas/Slot"
                     },
                     "block": {
-                        "description": "Block Id",
-                        "type": "string"
+                        "$ref": "#/components/schemas/BlockId"
                     },
                     "read_only": {
                         "description": "Wether the event was generated during  read only call",
@@ -3251,17 +3159,17 @@
                     },
                     "call_stack": {
                         "description": "Addresses",
+                        "title": "Address stack",
                         "type": "array",
                         "items": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/Address"
                         }
                     },
                     "index_in_slot": {
                         "type": "number"
                     },
                     "origin_operation_id": {
-                        "description": "Operation id",
-                        "type": "string"
+                        "$ref": "#/components/schemas/OperationId"
                     }
                 },
                 "additionalProperties": false
@@ -3275,7 +3183,8 @@
                 "type": "object",
                 "properties": {
                     "data": {
-                        "description": "String of the event you sended",
+                        "title": "Event data",
+                        "description": "String of the event",
                         "type": "string"
                     },
                     "context": {
@@ -3300,13 +3209,23 @@
                 "type": "object",
                 "properties": {
                     "period": {
-                        "type": "number"
+                        "$ref": "#/components/schemas/Period"
                     },
                     "thread": {
-                        "type": "number"
+                        "$ref": "#/components/schemas/Thread"
                     }
                 },
                 "additionalProperties": false
+            },
+            "Period": {
+                "title": "Period",
+                "description": "Slot period.",
+                "type": "number"
+            },
+            "Thread": {
+                "title": "Thread",
+                "description": "Slot thread.",
+                "type": "number"
             },
             "Staker": {
                 "title": "Staker",
@@ -3319,7 +3238,7 @@
                             "$ref": "#/components/schemas/Address"
                         },
                         "active_rolls": {
-                            "type": "number"
+                            "$ref": "#/components/schemas/RollAmount"
                         }
                     }
                 },
@@ -3371,8 +3290,8 @@
                 "additionalProperties": false
             },
             "Transaction": {
-                "title": "Transaction",
-                "description": "Transation",
+                "title": "Transaction Receipt",
+                "description": "Transaction operation receipt",
                 "required": [
                     "amount",
                     "recipient_address"
@@ -3380,18 +3299,17 @@
                 "type": "object",
                 "properties": {
                     "amount": {
-                        "description": "Represent an Amount in coins",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Amount"
                     },
                     "recipient_address": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/Address"
                     }
                 },
                 "additionalProperties": false
             },
             "Transfer": {
-                "title": "Transfer",
-                "description": "Describe a transfer of MAS",
+                "title": "Transfer Receipt",
+                "description": "MAS Transfer operation receipt",
                 "required": [
                     "from",
                     "to",
@@ -3406,35 +3324,36 @@
                 "properties": {
                     "from": {
                         "description": "Address of the sender",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Address"
                     },
                     "to": {
                         "description": "Address of the receiver",
-                        "type": "string"
+                        "$ref": "#/components/schemas/Address"
                     },
                     "amount": {
                         "description": "Amount transferred",
-                        "type": "integer"
+                        "$ref": "#/components/schemas/Amount"
                     },
                     "effective_amount_received": {
-                        "description": "Amount received by the receiver",
-                        "type": "integer"
+                        "$ref": "#/components/schemas/Amount"
                     },
                     "context": {
-                        "description": "Context of the transfer : operation or asyncronous execution",
+                        "description": "Context of the transfer : operation or asynchronous execution",
+                        "title": "Context",
                         "type": "object"
                     },
                     "succeed": {
                         "description": "True if the operation succeed otherwise false",
+                        "title": "isSuccess",
                         "type": "boolean"
                     },
                     "fee": {
                         "description": "Fees passed to the operation",
-                        "type": "number"
+                        "$ref": "#/components/schemas/Amount"
                     },
                     "block_id": {
                         "description": "ID of the block in which the operation is included",
-                        "type": "string"
+                        "$ref": "#/components/schemas/BlockId"
                     }
                 },
                 "additionalProperties": false
@@ -3456,8 +3375,7 @@
                 "type": "object",
                 "properties": {
                     "content": {
-                        "$ref": "#/components/schemas/Header",
-                        "description": "header type"
+                        "$ref": "#/components/schemas/Header"
                     },
                     "signature": {
                         "$ref": "#/components/schemas/Signature",
@@ -3565,14 +3483,6 @@
                 "description": "A Clique object",
                 "schema": {
                     "$ref": "#/components/schemas/Clique"
-                }
-            },
-            "DataStoreEntry": {
-                "name": "DataStoreEntry",
-                "summary": "DataStoreEntry",
-                "description": "A DataStoreEntry object",
-                "schema": {
-                    "$ref": "#/components/schemas/DataStoreEntry"
                 }
             },
             "DatastoreEntryInput": {

--- a/src/client/connector.ts
+++ b/src/client/connector.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import * as t from '../generated/client-types'
+import { rpcTypes as t } from 'src/generated'
 import { getHttpRpcClient, HttpRpcClient } from './http'
 import { ClientOptions } from './types'
 

--- a/src/client/formatObjects.ts
+++ b/src/client/formatObjects.ts
@@ -1,5 +1,7 @@
 import { NodeStatus } from '../generated/client-types'
 import { NodeStatusInfo } from '../provider'
+import { rpcTypes as t } from '../generated'
+import { ReadOnlyCallResult } from './types'
 
 export function formatNodeStatusObject(status: NodeStatus): NodeStatusInfo {
   return {
@@ -51,5 +53,27 @@ export function formatNodeStatusObject(status: NodeStatus): NodeStatusInfo {
     },
     chainId: status.chain_id,
     minimalFees: status.minimal_fees,
+  }
+}
+
+export function formatReadOnlyCallResponse(
+  res: t.ExecuteReadOnlyResponse
+): ReadOnlyCallResult {
+  return {
+    value: res.result.Ok ? new Uint8Array(res.result.Ok) : new Uint8Array(),
+    info: {
+      gasCost: res.gas_cost,
+      error: res.result.Error,
+      events: res.output_events,
+      stateChanges: {
+        ledgerChanges: res.state_changes.ledger_changes,
+        asyncPoolChanges: res.state_changes.async_pool_changes,
+        posChanges: res.state_changes.pos_changes,
+        executedOpsChanges: res.state_changes.executed_ops_changes,
+        executedDenunciationsChanges:
+          res.state_changes.executed_denunciations_changes,
+        executionTrailHashChange: res.state_changes.execution_trail_hash_change,
+      },
+    },
   }
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,17 +1,7 @@
-import { EventExecutionContext } from '../generated/client-types'
-
-export type Slot = {
-  period: number
-  thread: number
-}
+import { rpcTypes as t } from '../generated'
 
 export type ClientOptions = {
   retry: { retries: number; delay: number }
-}
-
-export type SCEvent = {
-  data: string
-  context: EventExecutionContext
 }
 
 export type SendOperationInput = {
@@ -21,8 +11,8 @@ export type SendOperationInput = {
 }
 
 export type EventFilter = {
-  start?: Slot
-  end?: Slot
+  start?: t.Slot
+  end?: t.Slot
   smartContractAddress?: string
   callerAddress?: string
   operationId?: string
@@ -35,7 +25,7 @@ export type ReadOnlyCallResult = {
   info: {
     gasCost: number
     error?: string
-    events: SCEvent[]
+    events: t.OutputEvents
     stateChanges: {
       ledgerChanges: Record<string, unknown>
       asyncPoolChanges: Record<string, unknown>[]

--- a/src/events/eventsPoller.ts
+++ b/src/events/eventsPoller.ts
@@ -1,6 +1,7 @@
 import { Provider } from '../provider'
-import { EventFilter, NB_THREADS, SCEvent, Slot } from '../client'
+import { EventFilter, NB_THREADS } from '../client'
 import EventEmitter from 'eventemitter3'
+import { rpcTypes as t } from '../generated'
 
 /** Smart Contracts Event Poller */
 export const ON_MASSA_EVENT_DATA = 'ON_MASSA_EVENT'
@@ -9,7 +10,7 @@ export const ON_MASSA_EVENT_ERROR = 'ON_MASSA_ERROR'
 export const DEFAULT_POLL_INTERVAL_MS = 1000
 
 // get the next slot
-function nextSlot(prevSlot: Slot): Slot {
+function nextSlot(prevSlot: t.Slot): t.Slot {
   const slot = prevSlot
   if (slot.thread < NB_THREADS - 1) {
     slot.thread++
@@ -25,7 +26,7 @@ function nextSlot(prevSlot: Slot): Slot {
  */
 export class EventPoller extends EventEmitter {
   private intervalId: NodeJS.Timeout
-  private lastSlot: Slot
+  private lastSlot: t.Slot
 
   /**
    * Constructor of the EventPoller object.
@@ -91,7 +92,7 @@ export class EventPoller extends EventEmitter {
   public static start(
     provider: Provider,
     eventsFilter: EventFilter,
-    onData?: (data: SCEvent[]) => void,
+    onData?: (data: t.OutputEvents) => void,
     onError?: (err: Error) => void,
     pollIntervalMs = DEFAULT_POLL_INTERVAL_MS
   ): { stopPolling: () => void } {

--- a/src/generated/client-types.ts
+++ b/src/generated/client-types.ts
@@ -1,16 +1,17 @@
 /**
  *
- * Max available gas
+ * Amount of gas
  *
  */
-export type NumberPsns2WbD = number;
+export type GasAmount = number;
 export type Integer2AHOqbcQ = number;
 /**
  *
- * Bytecode to execute
+ * Byte array
  *
  */
-export type UnorderedSetOfInteger2AHOqbcQjNvs9B0Z = Integer2AHOqbcQ[];
+export type Bytes = Integer2AHOqbcQ[];
+export type NullQu0Arl1F = null;
 /**
  *
  * Address
@@ -19,100 +20,73 @@ export type UnorderedSetOfInteger2AHOqbcQjNvs9B0Z = Integer2AHOqbcQ[];
 export type Address = string;
 /**
  *
- * An operation datastore
+ * Caller's address, optional
  *
  */
-export type UnorderedSetOfInteger2AHOqbcQtXvTMhya = Integer2AHOqbcQ[];
+export type AddressOption = NullQu0Arl1F | Address;
+export type UnorderedSetOfInteger2AHOqbcQarZIQlOy = Integer2AHOqbcQ[];
 /**
  *
- * Whether to start execution from final or active state
+ * Operation datastore TO FIX
  *
  */
-export type BooleanHNwwo80P = boolean;
+export type OperationDatastore = NullQu0Arl1F | UnorderedSetOfInteger2AHOqbcQarZIQlOy;
 /**
  *
- * Amount in coins, optional
+ * MAS amount in float string
  *
  */
-export type NumberZ1JdLCIz = number;
+export type Amount = string;
 /**
  *
- * Fee, optional
+ * MAS amount in float string
  *
  */
-export type NumberSnYk3VhE = number;
+export type AmountOption = NullQu0Arl1F | Amount;
 /**
  *
  * Read only bytecode execution
  *
  */
 export interface ReadOnlyBytecodeExecution {
-  max_gas: NumberPsns2WbD;
-  bytecode: UnorderedSetOfInteger2AHOqbcQjNvs9B0Z;
-  address?: Address;
-  operation_datastore?: UnorderedSetOfInteger2AHOqbcQtXvTMhya;
-  is_final?: BooleanHNwwo80P;
-  coins?: NumberZ1JdLCIz;
-  fee?: NumberSnYk3VhE;
+  max_gas: GasAmount;
+  bytecode: Bytes;
+  address?: AddressOption;
+  operation_datastore?: OperationDatastore;
+  fee?: AmountOption;
 }
-/**
- *
- * Target address
- *
- */
-export type StringYvGZTlwQ = string;
 /**
  *
  * Target function
  *
  */
-export type StringBtBJC5Iw = string;
+export type TargetFunction = string;
 /**
  *
- * Function parameter
+ * Serialized SC call params
  *
  */
-export type UnorderedSetOfInteger2AHOqbcQzYHdsLoW = Integer2AHOqbcQ[];
-export type NullQu0Arl1F = null;
-export type StringDoaGddGA = string;
-/**
- *
- * Caller's address, optional
- *
- */
-export type OneOfNullQu0Arl1FStringDoaGddGAHzYKhN99 = NullQu0Arl1F | StringDoaGddGA;
-/**
- *
- * Amount in coins, optional
- *
- */
-export type OneOfNullQu0Arl1FStringDoaGddGAEUSQB1KK = NullQu0Arl1F | StringDoaGddGA;
-/**
- *
- * Fee, optional
- *
- */
-export type OneOfNullQu0Arl1FStringDoaGddGANOhzhrxe = NullQu0Arl1F | StringDoaGddGA;
+export type SCCallParams = Integer2AHOqbcQ[];
 /**
  *
  * Read only call
  *
  */
 export interface ReadOnlyCall {
-  max_gas: NumberPsns2WbD;
-  target_address: StringYvGZTlwQ;
-  target_function: StringBtBJC5Iw;
-  parameter: UnorderedSetOfInteger2AHOqbcQzYHdsLoW;
-  caller_address: OneOfNullQu0Arl1FStringDoaGddGAHzYKhN99;
-  coins: OneOfNullQu0Arl1FStringDoaGddGAEUSQB1KK;
-  fee: OneOfNullQu0Arl1FStringDoaGddGANOhzhrxe;
+  max_gas: GasAmount;
+  target_address: Address;
+  target_function: TargetFunction;
+  parameter: SCCallParams;
+  caller_address: AddressOption;
+  coins: AmountOption;
+  fee: AmountOption;
 }
 /**
  *
- * true means final, false means candidate
+ * Operation is final
  *
  */
-export type Boolean7Xei3MDX = boolean;
+export type IsFinal = boolean;
 /**
  *
  * Address filter
@@ -120,7 +94,7 @@ export type Boolean7Xei3MDX = boolean;
  */
 export interface AddressFilter {
   address?: Address;
-  is_final?: Boolean7Xei3MDX;
+  is_final?: IsFinal;
 }
 /**
  *
@@ -128,11 +102,21 @@ export interface AddressFilter {
  *
  */
 export type BlockId = string;
-export type NumberHo1ClIqD = number;
-export type UnorderedSetOfInteger2AHOqbcQBha3UJIJ = Integer2AHOqbcQ[];
+/**
+ *
+ * after `expire_period` slot the operation won't be included in a block
+ *
+ */
+export type Period = number;
+/**
+ *
+ * Thread in which the operation can be included
+ *
+ */
+export type Thread = number;
 export interface DatastoreEntryInput {
   address: Address;
-  key: UnorderedSetOfInteger2AHOqbcQBha3UJIJ;
+  key: Bytes;
 }
 /**
  *
@@ -140,39 +124,28 @@ export interface DatastoreEntryInput {
  *
  */
 export interface Slot {
-  period: NumberHo1ClIqD;
-  thread: NumberHo1ClIqD;
+  period: Period;
+  thread: Thread;
 }
 /**
  *
- * Optional emitter address
+ * Endorsement id
  *
  */
-export type String5J7NQ8B1 = string;
+export type EndorsementId = string;
 /**
  *
- * Optional caller address
+ * Operation id
  *
  */
-export type StringCc6XlKeq = string;
+export type OperationId = string;
 /**
  *
- * Optional operation id
+ * Whether the event was generated in a failed executed or not
  *
  */
-export type StringUcQL9QGN = string;
-/**
- *
- * Optional filter to filter only candidate or final events
- *
- */
-export type BooleanObf9WMA0 = boolean;
-/**
- *
- * Optional filter to retrieve events generated in a failed execution
- *
- */
-export type BooleanAXlyTrPe = boolean;
+export type Error = boolean;
+export type NumberHo1ClIqD = number;
 /**
  *
  * `PrivateKey` is used for signature and decryption
@@ -181,16 +154,11 @@ export type BooleanAXlyTrPe = boolean;
 export type PrivateKey = string;
 /**
  *
- * Ip address
+ * Ipv4 or Ipv6 address
  *
  */
-export type StringBBdNk2Ku = string;
-/**
- *
- * ip address
- *
- */
-export type StringOGpKXaCP = string;
+export type IpAddress = string;
+export type StringDoaGddGA = string;
 /**
  *
  * the content creator public key
@@ -203,7 +171,6 @@ export type PublicKey = string;
  *
  */
 export type Signature = string;
-export type UnorderedSetOfInteger2AHOqbcQarZIQlOy = Integer2AHOqbcQ[];
 /**
  *
  * Operation input
@@ -212,7 +179,7 @@ export type UnorderedSetOfInteger2AHOqbcQarZIQlOy = Integer2AHOqbcQ[];
 export interface OperationInput {
   creator_public_key: PublicKey;
   signature: Signature;
-  serialized_content: UnorderedSetOfInteger2AHOqbcQarZIQlOy;
+  serialized_content: Bytes;
 }
 /**
  *
@@ -223,17 +190,6 @@ export interface Pagination {
   limit: NumberHo1ClIqD;
   offset: NumberHo1ClIqD;
 }
-export interface ExecuteAt {
-  period: NumberHo1ClIqD;
-  thread: NumberHo1ClIqD;
-}
-export type StringUJarsTOs = string;
-/**
- *
- * Included in case of success. The result of the execution
- *
- */
-export type UnorderedSetOfStringUJarsTOsgviiNMvH = StringUJarsTOs[];
 /**
  *
  * Included in case of error. The error message
@@ -246,51 +202,33 @@ export type StringOz2F8Z2Y = string;
  *
  */
 export interface ReadOnlyResult {
-  Ok?: UnorderedSetOfStringUJarsTOsgviiNMvH;
+  Ok?: Bytes;
   Error?: StringOz2F8Z2Y;
 }
 /**
  *
- * String of the event you sended
+ * String of the event
  *
  */
-export type StringBt9L6T1F = string;
+export type EventData = string;
 /**
  *
  * Wether the event was generated during  read only call
  *
  */
-export type BooleanQYH7IQYB = boolean;
+export type IsReadonly = boolean;
 /**
  *
  * Addresses, most recent at the end
  *
  */
-export type UnorderedSetOfAddressqhKJr2Tw = Address[];
+export type AddressStack = Address[];
 /**
  *
  * Index of the event in the slot
  *
  */
-export type NumberHGt16B6Y = number;
-/**
- *
- * Operation id
- *
- */
-export type OperationId = string;
-/**
- *
- * Whether the event is final
- *
- */
-export type BooleanSPcYqJj2 = boolean;
-/**
- *
- * Whether the event was generated in a failed executed or not
- *
- */
-export type BooleanIqtEc7R0 = boolean;
+export type IndexInSlot = number;
 /**
  *
  * Context generated by the execution context
@@ -299,24 +237,18 @@ export type BooleanIqtEc7R0 = boolean;
 export interface EventExecutionContext {
   slot: Slot;
   block?: BlockId;
-  read_only: BooleanQYH7IQYB;
-  call_stack: UnorderedSetOfAddressqhKJr2Tw;
-  index_in_slot: NumberHGt16B6Y;
+  read_only: IsReadonly;
+  call_stack: AddressStack;
+  index_in_slot: IndexInSlot;
   origin_operation_id?: OperationId;
-  is_final: BooleanSPcYqJj2;
-  is_error?: BooleanIqtEc7R0;
+  is_final: IsFinal;
+  is_error?: Error;
 }
 export interface SCOutputEvent {
-  data: StringBt9L6T1F;
+  data: EventData;
   context: EventExecutionContext;
 }
-export type UnorderedSetOfSCOutputEventHwhiOmzE = SCOutputEvent[];
-/**
- *
- * The gas cost for the execution
- *
- */
-export type NumberAIaYfWME = number;
+export type OutputEvents = SCOutputEvent[];
 /**
  *
  * ledger changes
@@ -363,58 +295,27 @@ export interface StateChanges {
   execution_trail_hash_change: StringIytPJwYq;
 }
 export interface ExecuteReadOnlyResponse {
-  executed_at: ExecuteAt;
+  executed_at: Slot;
   result: ReadOnlyResult;
-  output_events: UnorderedSetOfSCOutputEventHwhiOmzE;
-  gas_cost: NumberAIaYfWME;
+  output_events: OutputEvents;
+  gas_cost: GasAmount;
   state_changes: StateChanges;
 }
 /**
  *
- * The thread the address belongs to
+ * Amount of rolls
  *
  */
-export type NumberSYJcvZVm = number;
-/**
- *
- * The final balance
- *
- */
-export type StringFFlpWNJb = string;
-/**
- *
- * The final roll count
- *
- */
-export type NumberPAAsFK4N = number;
-export type UnorderedSetOfNumberHo1ClIqDAokMKuEf = NumberHo1ClIqD[];
-/**
- *
- * The final datastore keys
- *
- */
-export type UnorderedSetOfUnorderedSetOfNumberHo1ClIqDAokMKuEfIixaMtvV = UnorderedSetOfNumberHo1ClIqDAokMKuEf[];
-/**
- *
- * The candidate balance
- *
- */
-export type StringSZbUM3UB = string;
-/**
- *
- * The candidate roll count
- *
- */
-export type NumberUycrgn8X = number;
+export type RollAmount = number;
 /**
  *
  * The candidate datastore keys
  *
  */
-export type UnorderedSetOfUnorderedSetOfNumberHo1ClIqDAokMKuEfmvpf11Qe = UnorderedSetOfNumberHo1ClIqDAokMKuEf[];
-export interface ObjectOfSlotStringDoaGddGAQZyvCcRS {
+export type DatastoreKeys = Bytes[];
+export interface ObjectOfSlotAmountWrpyYBUS {
   slot?: Slot;
-  amount?: StringDoaGddGA;
+  amount?: Amount;
   [k: string]: any;
 }
 /**
@@ -422,14 +323,9 @@ export interface ObjectOfSlotStringDoaGddGAQZyvCcRS {
  * The deferred credits
  *
  */
-export type UnorderedSetOfObjectOfSlotStringDoaGddGAQZyvCcRS732D8Bc5 = ObjectOfSlotStringDoaGddGAQZyvCcRS[];
-/**
- *
- * The next block draws
- *
- */
-export type UnorderedSetOfSlotpnXhUhWs = Slot[];
-export interface ObjectOfSlotNumberHo1ClIqDMPMjgxrm {
+export type UnorderedSetOfObjectOfSlotAmountWrpyYBUSwrpyYBUS = ObjectOfSlotAmountWrpyYBUS[];
+export type UnorderedSetOfSlotwrpyYBUS = Slot[];
+export interface ObjectOfSlotNumberHo1ClIqDWrpyYBUS {
   slot?: Slot;
   index?: NumberHo1ClIqD;
   [k: string]: any;
@@ -439,87 +335,69 @@ export interface ObjectOfSlotNumberHo1ClIqDMPMjgxrm {
  * The next endorsement draws
  *
  */
-export type UnorderedSetOfObjectOfSlotNumberHo1ClIqDMPMjgxrm06Ae306Q = ObjectOfSlotNumberHo1ClIqDMPMjgxrm[];
+export type UnorderedSetOfObjectOfSlotNumberHo1ClIqDWrpyYBUSwrpyYBUS = ObjectOfSlotNumberHo1ClIqDWrpyYBUS[];
+export type UnorderedSetOfBlockIdwrpyYBUS = BlockId[];
 /**
  *
- * BlockIds of created blocks
+ * Operations
  *
  */
-export type UnorderedSetOfBlockIdpdDCfi0P = BlockId[];
-/**
- *
- * OperationIds of created operations
- *
- */
-export type UnorderedSetOfOperationId971EzIER = OperationId[];
-/**
- *
- * Endorsement id
- *
- */
-export type EndorsementId = string;
+export type UnorderedSetOfOperationIdwrpyYBUS = OperationId[];
 /**
  *
  * EndorsementIds of created endorsements
  *
  */
-export type UnorderedSetOfEndorsementIdNN27ZC1J = EndorsementId[];
-export type BooleanVyG3AETh = boolean;
-export type OneOfNullQu0Arl1FNumberHo1ClIqDKWtQwzS8 = NullQu0Arl1F | NumberHo1ClIqD;
+export type UnorderedSetOfEndorsementIdwrpyYBUS = EndorsementId[];
+export type OneOfRollAmountNullQu0Arl1FGg9ZJg6R = NullQu0Arl1F | RollAmount;
 export interface ExecutionAddressCycleInfo {
   cycle: NumberHo1ClIqD;
-  is_final: BooleanVyG3AETh;
+  is_final: IsFinal;
   ok_count: NumberHo1ClIqD;
   nok_count: NumberHo1ClIqD;
-  active_rolls?: OneOfNullQu0Arl1FNumberHo1ClIqDKWtQwzS8;
+  active_rolls?: OneOfRollAmountNullQu0Arl1FGg9ZJg6R;
 }
 /**
  *
  * Cycle infos
  *
  */
-export type UnorderedSetOfExecutionAddressCycleInfo8D3STgcL = ExecutionAddressCycleInfo[];
+export type UnorderedSetOfExecutionAddressCycleInfowrpyYBUS = ExecutionAddressCycleInfo[];
 export interface AddressInfo {
   address: Address;
-  thread: NumberSYJcvZVm;
-  final_balance: StringFFlpWNJb;
-  final_roll_count: NumberPAAsFK4N;
-  final_datastore_keys: UnorderedSetOfUnorderedSetOfNumberHo1ClIqDAokMKuEfIixaMtvV;
-  candidate_balance: StringSZbUM3UB;
-  candidate_roll_count: NumberUycrgn8X;
-  candidate_datastore_keys: UnorderedSetOfUnorderedSetOfNumberHo1ClIqDAokMKuEfmvpf11Qe;
-  deferred_credits: UnorderedSetOfObjectOfSlotStringDoaGddGAQZyvCcRS732D8Bc5;
-  next_block_draws: UnorderedSetOfSlotpnXhUhWs;
-  next_endorsement_draws: UnorderedSetOfObjectOfSlotNumberHo1ClIqDMPMjgxrm06Ae306Q;
-  created_blocks: UnorderedSetOfBlockIdpdDCfi0P;
-  created_operations: UnorderedSetOfOperationId971EzIER;
-  created_endorsements: UnorderedSetOfEndorsementIdNN27ZC1J;
-  cycle_infos: UnorderedSetOfExecutionAddressCycleInfo8D3STgcL;
+  thread: Thread;
+  final_balance: Amount;
+  final_roll_count: RollAmount;
+  final_datastore_keys: DatastoreKeys;
+  candidate_balance: Amount;
+  candidate_roll_count: RollAmount;
+  candidate_datastore_keys: DatastoreKeys;
+  deferred_credits: UnorderedSetOfObjectOfSlotAmountWrpyYBUSwrpyYBUS;
+  next_block_draws: UnorderedSetOfSlotwrpyYBUS;
+  next_endorsement_draws: UnorderedSetOfObjectOfSlotNumberHo1ClIqDWrpyYBUSwrpyYBUS;
+  created_blocks: UnorderedSetOfBlockIdwrpyYBUS;
+  created_operations: UnorderedSetOfOperationIdwrpyYBUS;
+  created_endorsements: UnorderedSetOfEndorsementIdwrpyYBUS;
+  cycle_infos: UnorderedSetOfExecutionAddressCycleInfowrpyYBUS;
 }
-/**
- *
- * true if final
- *
- */
-export type BooleanZxUVUy6M = boolean;
 /**
  *
  * true if candidate
  *
  */
-export type BooleanMazVJcyf = boolean;
+export type IsCandidate = boolean;
 /**
  *
  * true if discarded
  *
  */
-export type BooleanHJvzO9WE = boolean;
+export type IsDiscarded = boolean;
 /**
  *
- * true if in the greatest clique
+ * true if in the last clique
  *
  */
-export type BooleanHjqkwJfo = boolean;
+export type InBlockClique = boolean;
 /**
  *
  * Current version
@@ -532,7 +410,6 @@ export type NumberTbrodUsH = number;
  *
  */
 export type OneOfNullQu0Arl1FNumberHo1ClIqD4U4GpKJM = NullQu0Arl1F | NumberHo1ClIqD;
-export type UnorderedSetOfStringDoaGddGADvj0XlFa = StringDoaGddGA[];
 /**
  *
  * Endorsement content
@@ -543,9 +420,9 @@ export interface EndorsementContent {
   index: NumberHo1ClIqD;
   endorsed_block: BlockId;
 }
-export interface ObjectOfStringDoaGddGAEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUS {
+export interface ObjectOfSignatureEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUS {
   content?: EndorsementContent;
-  signature?: StringDoaGddGA;
+  signature?: Signature;
   content_creator_pub_key?: PublicKey;
   content_creator_address?: Address;
   id?: EndorsementId;
@@ -556,46 +433,41 @@ export interface ObjectOfStringDoaGddGAEndorsementIdPublicKeyAddressEndorsementC
  * Endorsements
  *
  */
-export type UnorderedSetOfObjectOfStringDoaGddGAEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUSwrpyYBUS = ObjectOfStringDoaGddGAEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUS[];
-export interface ObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUS {
-  public_key?: StringDoaGddGA;
-  slot?: Integer2AHOqbcQ;
+export type UnorderedSetOfObjectOfSignatureEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUSwrpyYBUS = ObjectOfSignatureEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUS[];
+export interface ObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUS {
+  public_key?: PublicKey;
+  slot?: Slot;
   index?: Integer2AHOqbcQ;
   hash_1?: StringDoaGddGA;
   hash_2?: StringDoaGddGA;
-  signature_1?: StringDoaGddGA;
-  signature_2?: StringDoaGddGA;
+  signature_1?: Signature;
+  signature_2?: Signature;
   [k: string]: any;
 }
-export interface ObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUS {
-  public_key?: StringDoaGddGA;
-  slot?: Integer2AHOqbcQ;
+export interface ObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUS {
+  public_key?: PublicKey;
+  slot?: Slot;
   hash_1?: StringDoaGddGA;
   hash_2?: StringDoaGddGA;
-  signature_1?: StringDoaGddGA;
-  signature_2?: StringDoaGddGA;
+  signature_1?: Signature;
+  signature_2?: Signature;
   [k: string]: any;
 }
-export type OneOfObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUSGJLAASWC = ObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUS | ObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUS;
+export type OneOfObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUSTKq8XnCL = ObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUS | ObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUS;
 /**
  *
  * Denunciations
  *
  */
-export type UnorderedSetOfOneOfObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUSGJLAASWCwrpyYBUS = OneOfObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUSGJLAASWC[];
-/**
- *
- * header type
- *
- */
+export type UnorderedSetOfOneOfObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUSTKq8XnCLwrpyYBUS = OneOfObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUSTKq8XnCL[];
 export interface Header {
   current_version?: NumberTbrodUsH;
   announced_version?: OneOfNullQu0Arl1FNumberHo1ClIqD4U4GpKJM;
   operation_merkle_root: StringDoaGddGA;
-  parents: UnorderedSetOfStringDoaGddGADvj0XlFa;
+  parents: UnorderedSetOfBlockIdwrpyYBUS;
   slot: Slot;
-  endorsements?: UnorderedSetOfObjectOfStringDoaGddGAEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUSwrpyYBUS;
-  denunciations?: UnorderedSetOfOneOfObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUSGJLAASWCwrpyYBUS;
+  endorsements?: UnorderedSetOfObjectOfSignatureEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUSwrpyYBUS;
+  denunciations?: UnorderedSetOfOneOfObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUSTKq8XnCLwrpyYBUS;
 }
 /**
  *
@@ -609,25 +481,19 @@ export interface WrappedHeader {
   content_creator_address: Address;
   id?: BlockId;
 }
-/**
- *
- * Operations
- *
- */
-export type UnorderedSetOfStringDoaGddGAucaTsQyS = StringDoaGddGA[];
 export interface Block {
   header: WrappedHeader;
-  operations: UnorderedSetOfStringDoaGddGAucaTsQyS;
+  operations: UnorderedSetOfOperationIdwrpyYBUS;
 }
 export interface BlockInfoContent {
-  is_final: BooleanZxUVUy6M;
-  is_candidate: BooleanMazVJcyf;
-  is_discarded?: BooleanHJvzO9WE;
-  is_in_blockclique: BooleanHjqkwJfo;
+  is_final: IsFinal;
+  is_candidate: IsCandidate;
+  is_discarded?: IsDiscarded;
+  is_in_blockclique: InBlockClique;
   block: Block;
 }
 export interface BlockInfo {
-  id: StringDoaGddGA;
+  id: BlockId;
   content?: BlockInfoContent;
 }
 /**
@@ -660,89 +526,48 @@ export interface Clique {
 }
 /**
  *
- * The candidate datastore entry value bytes
- *
- */
-export type OneOfNullQu0Arl1FUnorderedSetOfInteger2AHOqbcQarZIQlOy81SHPJsX = UnorderedSetOfInteger2AHOqbcQarZIQlOy | NullQu0Arl1F;
-/**
- *
  * The final datastore entry value bytes
  *
  */
-export type OneOfNullQu0Arl1FUnorderedSetOfInteger2AHOqbcQarZIQlOyGOQJrRPK = UnorderedSetOfInteger2AHOqbcQarZIQlOy | NullQu0Arl1F;
+export type BytesOption = NullQu0Arl1F | Bytes;
 /**
  *
  * Datastore entry
  *
  */
 export interface DatastoreEntryOutput {
-  candidate_value: OneOfNullQu0Arl1FUnorderedSetOfInteger2AHOqbcQarZIQlOy81SHPJsX;
-  final_value: OneOfNullQu0Arl1FUnorderedSetOfInteger2AHOqbcQarZIQlOyGOQJrRPK;
+  candidate_value: BytesOption;
+  final_value: BytesOption;
 }
 /**
  *
- * Address of the sender
+ * Context of the transfer : operation or asynchronous execution
  *
  */
-export type StringYVTrFSaQ = string;
-/**
- *
- * Address of the receiver
- *
- */
-export type StringZyWeUFZ8 = string;
-/**
- *
- * Amount transferred
- *
- */
-export type IntegerCOVAu0Eq = number;
-/**
- *
- * Amount received by the receiver
- *
- */
-export type IntegerVC2Agt39 = number;
-/**
- *
- * Context of the transfer : operation or asyncronous execution
- *
- */
-export interface Object0XCk2T5H { [key: string]: any; }
+export interface Context { [key: string]: any; }
 /**
  *
  * True if the operation succeed otherwise false
  *
  */
-export type BooleanYDqyb5Vp = boolean;
+export type IsSuccess = boolean;
 /**
  *
- * Fees passed to the operation
+ * MAS Transfer operation receipt
  *
  */
-export type NumberV8R93Gu7 = number;
-/**
- *
- * ID of the block in which the operation is included
- *
- */
-export type StringUyVBK2CK = string;
-/**
- *
- * Describe a transfer of MAS
- *
- */
-export interface Transfer {
-  from: StringYVTrFSaQ;
-  to: StringZyWeUFZ8;
-  amount: IntegerCOVAu0Eq;
-  effective_amount_received: IntegerVC2Agt39;
-  context: Object0XCk2T5H;
-  succeed: BooleanYDqyb5Vp;
-  fee: NumberV8R93Gu7;
-  block_id: StringUyVBK2CK;
+export interface TransferReceipt {
+  from: Address;
+  to: Address;
+  amount: Amount;
+  effective_amount_received: Amount;
+  context: Context;
+  succeed: IsSuccess;
+  fee: Amount;
+  block_id: BlockId;
 }
-export type UnorderedSetOfTransferQEyQHpyL = Transfer[];
+export type UnorderedSetOfTransferReceiptzpyvh8AY = TransferReceipt[];
+export type BooleanVyG3AETh = boolean;
 /**
  *
  * Block Id
@@ -759,7 +584,7 @@ export interface Endorsement {
   content_creator_pub_key: PublicKey;
   content_creator_address?: Address;
   id?: EndorsementId;
-  signature: StringDoaGddGA;
+  signature: Signature;
 }
 /**
  *
@@ -770,42 +595,30 @@ export interface EndorsementInfo {
   id: EndorsementId;
   in_pool: BooleanVyG3AETh;
   in_blocks: UnorderedSetOfBlockId7G1Sy5Qv;
-  is_final: BooleanVyG3AETh;
+  is_final: IsFinal;
   endorsement: Endorsement;
 }
 /**
  *
- * Public key
+ * true if incompatible with a final block
  *
  */
-export type StringVuVvWRdT = string;
-/**
- *
- * Block Id
- *
- */
-export type StringU8LlHDu1 = string;
+export type Stale = boolean;
 /**
  *
  * As many block Ids as there are threads
  *
  */
-export type UnorderedSetOfStringDoaGddGAMZnHm9WS = StringDoaGddGA[];
+export type UnorderedSetOfBlockIdNY3ZAj2A = BlockId[];
 export interface GraphInterval {
-  creator: StringVuVvWRdT;
-  id: StringU8LlHDu1;
-  is_final: BooleanVyG3AETh;
-  is_in_blockclique: BooleanVyG3AETh;
-  is_stale: BooleanVyG3AETh;
-  parents: UnorderedSetOfStringDoaGddGAMZnHm9WS;
+  creator: PublicKey;
+  id: BlockId;
+  is_final: IsFinal;
+  is_in_blockclique: InBlockClique;
+  is_stale: Stale;
+  parents: UnorderedSetOfBlockIdNY3ZAj2A;
   slot: Slot;
 }
-/**
- *
- * Operation id
- *
- */
-export type StringYTemzr68 = string;
 /**
  *
  * Block ids
@@ -825,124 +638,66 @@ export type BooleanSJ3TNusg = boolean;
  * True if the operation is final (for example in a final block)
  *
  */
-export type OneOfBooleanVyG3AEThNullQu0Arl1FCuqCzoUJ = NullQu0Arl1F | BooleanVyG3AETh;
-/**
- *
- * Thread in which the operation can be included
- *
- */
-export type NumberZoWtBk8U = number;
-/**
- *
- * the fee they have decided for this operation
- *
- */
-export type StringV3754ZDT = string;
-/**
- *
- * after `expire_period` slot the operation won't be included in a block
- *
- */
-export type NumberSbfeGjn7 = number;
-/**
- *
- * Represent an Amount in coins
- *
- */
-export type StringNIrlyE1J = string;
+export type IsFinalOperation = NullQu0Arl1F | IsFinal;
 /**
  *
  * transfer coins from sender to recipient
  *
  */
-export interface Transaction {
-  amount: StringNIrlyE1J;
-  recipient_address: StringDoaGddGA;
+export interface TransactionReceipt {
+  amount: Amount;
+  recipient_address: Address;
 }
-/**
- *
- * Vec of bytes to execute
- *
- */
-export type UnorderedSetOfNumberHo1ClIqDd5W02PgX = NumberHo1ClIqD[];
-/**
- *
- * Maximum amount of gas that the execution of the contract is allowed to cost.
- *
- */
-export type NumberQUXtpAPK = number;
-export interface ObjectOfUnorderedSetOfInteger2AHOqbcQarZIQlOyUnorderedSetOfInteger2AHOqbcQarZIQlOyDbxIogvI {
-  entry?: UnorderedSetOfInteger2AHOqbcQarZIQlOy;
-  bytes?: UnorderedSetOfInteger2AHOqbcQarZIQlOy;
-  [k: string]: any;
-}
+export type UnorderedSetOfBytes0JFPBP6Z = Bytes[];
 /**
  *
  * A tuple which contains (key, value)
  *
  */
-export interface Datastore { [key: string]: any; }
+export type DatastoreEntry = UnorderedSetOfBytes0JFPBP6Z[];
 /**
  *
  * Execute a smart contract.
  *
  */
-export interface ExecuteSC {
-  data: UnorderedSetOfNumberHo1ClIqDd5W02PgX;
-  max_gas: NumberQUXtpAPK;
-  datastore: Datastore;
+export interface ExecuteSCReceipt {
+  data: Bytes;
+  max_gas: GasAmount;
+  datastore: DatastoreEntry;
 }
 /**
  *
- * Function name
+ * Contract Function name to call
  *
  */
-export type String7HCIMJir = string;
-/**
- *
- * Parameter to pass to the function
- *
- */
-export type StringSjIor0MV = string;
-/**
- *
- * Amount
- *
- */
-export type Number5Mo1HId6 = number;
+export type FunctionName = string;
 /**
  *
  * Calls an exported function from a stored smart contract
  *
  */
-export interface CallSC {
+export interface CallSCReceipt {
   target_addr: Address;
-  target_func: String7HCIMJir;
-  param: StringSjIor0MV;
-  max_gas: NumberHo1ClIqD;
-  coins: Number5Mo1HId6;
+  target_func: FunctionName;
+  param: SCCallParams;
+  max_gas: GasAmount;
+  coins: Amount;
 }
-/**
- *
- * roll count
- *
- */
-export type NumberJdJmnq9D = number;
 /**
  *
  * the sender buys `roll_count` rolls. Roll price is defined in configuration
  *
  */
-export interface RollBuy {
-  roll_count: NumberJdJmnq9D;
+export interface RollBuyReceipt {
+  roll_count: RollAmount;
 }
 /**
  *
  * the sender sells `roll_count` rolls. Roll price is defined in configuration
  *
  */
-export interface RollSell {
-  roll_count: NumberJdJmnq9D;
+export interface RollSellReceipt {
+  roll_count: RollAmount;
 }
 /**
  *
@@ -950,11 +705,11 @@ export interface RollSell {
  *
  */
 export interface OperationType {
-  Transaction?: Transaction;
-  ExecutSC?: ExecuteSC;
-  CallSC?: CallSC;
-  RollBuy?: RollBuy;
-  RollSell?: RollSell;
+  Transaction?: TransactionReceipt;
+  ExecutSC?: ExecuteSCReceipt;
+  CallSC?: CallSCReceipt;
+  RollBuy?: RollBuyReceipt;
+  RollSell?: RollSellReceipt;
 }
 /**
  *
@@ -962,13 +717,13 @@ export interface OperationType {
  *
  */
 export interface Operation {
-  fee: StringV3754ZDT;
-  expire_period: NumberSbfeGjn7;
+  fee: Amount;
+  expire_period: Period;
   op: OperationType;
 }
 /**
  *
- * The operation itself
+ * signed operation
  *
  */
 export interface WrappedOperation {
@@ -990,17 +745,17 @@ export type OneOfBooleanVyG3AEThNullQu0Arl1FE3Qax0Os = NullQu0Arl1F | BooleanVyG
  *
  */
 export interface OperationInfo {
-  id: StringYTemzr68;
+  id: OperationId;
   in_blocks: UnorderedSetOfBlockIdyEy9Dvpn;
   in_pool: BooleanSJ3TNusg;
-  is_operation_final: OneOfBooleanVyG3AEThNullQu0Arl1FCuqCzoUJ;
-  thread: NumberZoWtBk8U;
+  is_operation_final: IsFinalOperation;
+  thread: Thread;
   operation: WrappedOperation;
   op_exec_status?: OneOfBooleanVyG3AEThNullQu0Arl1FE3Qax0Os;
 }
-export interface ObjectOfAddressNumberHo1ClIqDFbgdJFtJ {
+export interface ObjectOfAddressRollAmountUf3B9Cb5 {
   address?: Address;
-  active_rolls?: NumberHo1ClIqD;
+  active_rolls?: RollAmount;
   [k: string]: any;
 }
 /**
@@ -1064,20 +819,20 @@ export type NumberAxwlzLso = number;
  *
  */
 export interface Config {
-  block_reward: StringNIrlyE1J;
+  block_reward: Amount;
   delta_f0: Number2A9FvvYh;
   end_timestamp?: OneOfNullQu0Arl1FNumberHo1ClIqDXysINzQy;
   genesis_timestamp: NumberSgfzurLm;
   max_block_size?: NumberUwkWWxaa;
   operation_validity_periods: NumberTs6Cn6JQ;
   periods_per_cycle: NumberGrsxxfaH;
-  roll_price: StringNIrlyE1J;
+  roll_price: Amount;
   t0: Number8ImKBhpQ;
   thread_count: NumberAxwlzLso;
 }
-export interface ObjectOfStringDoaGddGAStringDoaGddGAXJdFCZe6 {
+export interface ObjectOfStringDoaGddGAIpAddressWrpyYBUS {
   node_id?: StringDoaGddGA;
-  ip_address?: StringDoaGddGA;
+  ip_address?: IpAddress;
   [k: string]: any;
 }
 /**
@@ -1181,7 +936,7 @@ export type StringOFgZzVe7 = string;
  * Optional node ip if provided
  *
  */
-export type OneOfNullQu0Arl1FStringDoaGddGANsst9HIR = NullQu0Arl1F | StringDoaGddGA;
+export type OneOfIpAddressNullQu0Arl1FXaFV5TPI = NullQu0Arl1F | IpAddress;
 /**
  *
  * Pool stats
@@ -1237,35 +992,11 @@ export interface ExecutionStats {
  *
  */
 export type NumberBte4OVdF = number;
-/**
- *
- * Minimal fee
- *
- */
-export type StringTXHumHoA = string;
 type AlwaysFalse = any;
-/**
- *
- * Ip address
- *
- */
-export type IpAddress = string;
-/**
- *
- * public key
- *
- */
-export type StringTPMT1Yxd = string;
-/**
- *
- * signature
- *
- */
-export type StringXHbmHEWh = string;
-export type UnorderedSetOfStakerX7P278VS = Staker[];
-export interface ObjectOfNumberHo1ClIqDBlockIdHCnqqlza {
+export type UnorderedSetOfStakerdplIH7J8 = Staker[];
+export interface ObjectOfPeriodBlockIdWrpyYBUS {
   BlockId?: BlockId;
-  period?: NumberHo1ClIqD;
+  period?: Period;
   [k: string]: any;
 }
 /**
@@ -1276,16 +1007,10 @@ export interface ObjectOfNumberHo1ClIqDBlockIdHCnqqlza {
 export interface BlockParent { [key: string]: any; }
 /**
  *
- * true if incompatible with a final block
- *
- */
-export type Boolean4XbLtRCK = boolean;
-/**
- *
  * Operations
  *
  */
-export type UnorderedSetOfOperationInfowrpyYBUS = OperationInfo[];
+export type Operations = OperationInfo[];
 /**
  *
  * filled block
@@ -1293,21 +1018,21 @@ export type UnorderedSetOfOperationInfowrpyYBUS = OperationInfo[];
  */
 export interface FilledBlock {
   header: WrappedHeader;
-  operations: UnorderedSetOfOperationInfowrpyYBUS;
+  operations: Operations;
 }
 export interface FilledBlockInfoContent {
-  is_final: BooleanZxUVUy6M;
-  is_stale: Boolean4XbLtRCK;
-  is_in_blockclique: BooleanHjqkwJfo;
+  is_final: IsFinal;
+  is_stale: Stale;
+  is_in_blockclique: InBlockClique;
   block: FilledBlock;
 }
-export type UnorderedSetOfReadOnlyBytecodeExecutionK4Ht8Zdn = ReadOnlyBytecodeExecution[];
-export type UnorderedSetOfReadOnlyCallm6DMxyzd = ReadOnlyCall[];
+export type UnorderedSetOfReadOnlyBytecodeExecutionZbvNyXvD = ReadOnlyBytecodeExecution[];
+export type UnorderedSetOfReadOnlyCallOGx8T3Ix = ReadOnlyCall[];
 export type UnorderedSetOfAddressjJsnATCO = Address[];
-export type UnorderedSetOfAddressFilteraFrapw7X = AddressFilter[];
+export type AddressList = AddressFilter[];
 export type UnorderedSetOfBlockIdZXK9XY8A = BlockId[];
-export type UnorderedSetOfDatastoreEntryInputBdlngHsZ = DatastoreEntryInput[];
-export type UnorderedSetOfSlotn0BdrHhh = Slot[];
+export type UnorderedSetOfDatastoreEntryInputLrTgdYH8 = DatastoreEntryInput[];
+export type UnorderedSetOfEndorsementIdqnHAk5M0 = EndorsementId[];
 /**
  *
  * Event filter
@@ -1316,20 +1041,27 @@ export type UnorderedSetOfSlotn0BdrHhh = Slot[];
 export interface EventFilter {
   start?: Slot;
   end?: Slot;
-  emitter_address?: String5J7NQ8B1;
-  original_caller_address?: StringCc6XlKeq;
-  original_operation_id?: StringUcQL9QGN;
-  is_final?: BooleanObf9WMA0;
-  is_error?: BooleanAXlyTrPe;
+  emitter_address?: Address;
+  original_caller_address?: Address;
+  original_operation_id?: OperationId;
+  is_final?: IsFinal;
+  is_error?: Error;
 }
 export interface ObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75Fq {
   start?: NumberHo1ClIqD;
   end?: NumberHo1ClIqD;
 }
+export type UnorderedSetOfOperationId5TxbV4NZ = OperationId[];
 export type UnorderedSetOfPrivateKeyG69QLiLP = PrivateKey[];
-export type UnorderedSetOfStringBBdNk2Kup3WUWKiM = StringBBdNk2Ku[];
-export type UnorderedSetOfStringOGpKXaCP4RgV7KAw = StringOGpKXaCP[];
-export type UnorderedSetOfOperationInput9XcIbRG1 = OperationInput[];
+/**
+ *
+ * Array of Ipv4 or Ipv6 address
+ *
+ */
+export type IpAddressList = IpAddress[];
+export type UnorderedSetOfStringDoaGddGADvj0XlFa = StringDoaGddGA[];
+export type UnorderedSetOfIpAddressiIc9WbOi = IpAddress[];
+export type UnorderedSetOfOperationInputx51DfMZX = OperationInput[];
 /**
  *
  * ApiRequest for apiV2
@@ -1339,15 +1071,15 @@ export interface ApiRequest {
   page_request?: Pagination;
 }
 export type UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS = ExecuteReadOnlyResponse[];
-export type UnorderedSetOfAddressInfoCm3Tm6FQ = AddressInfo[];
-export type UnorderedSetOfStringUJarsTOsGY6FcFnU = StringUJarsTOs[];
+export type UnorderedSetOfAddressInfowrpyYBUS = AddressInfo[];
+export type BytecodeList = Bytes[];
 export type UnorderedSetOfBlockInfowrpyYBUS = BlockInfo[];
 export type UnorderedSetOfCliqueeS9LyMHx = Clique[];
-export type UnorderedSetOfDatastoreEntryOutputhcgFMMvn = DatastoreEntryOutput[];
-export type UnorderedSetOfUnorderedSetOfTransferQEyQHpyLoFgVJgXU = UnorderedSetOfTransferQEyQHpyL[];
+export type UnorderedSetOfDatastoreEntryOutputgBhWTzxI = DatastoreEntryOutput[];
+export type UnorderedSetOfUnorderedSetOfTransferReceiptzpyvh8AYeEDRSdp7 = UnorderedSetOfTransferReceiptzpyvh8AY[];
 export type UnorderedSetOfEndorsementInfowrpyYBUS = EndorsementInfo[];
 export type UnorderedSetOfGraphIntervalwrpyYBUS = GraphInterval[];
-export type UnorderedSetOfOperationInfoMdPofISE = OperationInfo[];
+export type UnorderedSetOfOperationInfowrpyYBUS = OperationInfo[];
 /**
  *
  * Node status
@@ -1365,36 +1097,34 @@ export interface NodeStatus {
   network_stats: NetworkStats;
   next_slot: Slot;
   node_id: StringOFgZzVe7;
-  node_ip?: OneOfNullQu0Arl1FStringDoaGddGANsst9HIR;
+  node_ip?: OneOfIpAddressNullQu0Arl1FXaFV5TPI;
   pool_stats: PoolStats;
   version: Version;
   execution_stats: ExecutionStats;
   chain_id: NumberBte4OVdF;
-  minimal_fees?: StringTXHumHoA;
+  minimal_fees?: Amount;
 }
-export type UnorderedSetOfIpAddressWpGgzO6M = IpAddress[];
 /**
  *
  * Public key and a signature it has produced used for serialization/deserialization purpose
  *
  */
 export interface PubkeySig {
-  public_key: StringTPMT1Yxd;
-  signature: StringXHbmHEWh;
+  public_key: PublicKey;
+  signature: Signature;
 }
-export type UnorderedSetOfOperationId5TxbV4NZ = OperationId[];
 /**
  *
  * PagedVec of stakers for apiV2
  *
  */
 export interface PagedVecStaker {
-  content?: UnorderedSetOfStakerX7P278VS;
+  content?: UnorderedSetOfStakerdplIH7J8;
   total_count?: NumberHo1ClIqD;
 }
-export type UnorderedSetOfBlockParentxrssVm84 = BlockParent[];
+export type UnorderedSetOfBlockParentwrpyYBUS = BlockParent[];
 export interface FilledBlockInfo {
-  id: StringDoaGddGA;
+  id: OperationId;
   content?: FilledBlockInfoContent;
 }
 /**
@@ -1402,46 +1132,46 @@ export interface FilledBlockInfo {
  * Generated! Represents an alias to any of the provided schemas
  *
  */
-export type AnyOfUnorderedSetOfReadOnlyBytecodeExecutionK4Ht8ZdnUnorderedSetOfReadOnlyCallm6DMxyzdUnorderedSetOfAddressjJsnATCOUnorderedSetOfAddressFilteraFrapw7XUnorderedSetOfBlockIdZXK9XY8ASlotUnorderedSetOfDatastoreEntryInputBdlngHsZUnorderedSetOfSlotn0BdrHhhUnorderedSetOfStringDoaGddGADvj0XlFaEventFilterObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75FqUnorderedSetOfStringDoaGddGADvj0XlFaPaginationUnorderedSetOfPrivateKeyG69QLiLPUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringDoaGddGADvj0XlFaUnorderedSetOfStringDoaGddGADvj0XlFaUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfAddressjJsnATCOStringUJarsTOsUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringOGpKXaCP4RgV7KAwUnorderedSetOfOperationInput9XcIbRG1ApiRequestInteger2AHOqbcQInteger2AHOqbcQInteger2AHOqbcQInteger2AHOqbcQUnorderedSetOfExecuteReadOnlyResponsewrpyYBUSUnorderedSetOfExecuteReadOnlyResponsewrpyYBUSUnorderedSetOfAddressInfoCm3Tm6FQUnorderedSetOfStringUJarsTOsGY6FcFnUUnorderedSetOfBlockInfowrpyYBUSBlockUnorderedSetOfCliqueeS9LyMHxUnorderedSetOfDatastoreEntryOutputhcgFMMvnUnorderedSetOfUnorderedSetOfTransferQEyQHpyLoFgVJgXUUnorderedSetOfEndorsementInfowrpyYBUSUnorderedSetOfSCOutputEventHwhiOmzEUnorderedSetOfGraphIntervalwrpyYBUSUnorderedSetOfOperationInfoMdPofISEUnorderedSetOfStakerX7P278VSNodeStatusAlwaysFalseUnorderedSetOfAddressjJsnATCOAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseUnorderedSetOfIpAddressWpGgzO6MUnorderedSetOfIpAddressWpGgzO6MAlwaysFalseUnorderedSetOfIpAddressWpGgzO6MAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalsePubkeySigAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseUnorderedSetOfOperationId5TxbV4NZPagedVecStakerUnorderedSetOfBlockParentxrssVm84VersionBlockInfoWrappedHeaderFilledBlockInfoOperationBooleanVyG3AEThBooleanVyG3AEThBooleanVyG3AEThBooleanVyG3AETh = UnorderedSetOfReadOnlyBytecodeExecutionK4Ht8Zdn | UnorderedSetOfReadOnlyCallm6DMxyzd | UnorderedSetOfAddressjJsnATCO | UnorderedSetOfAddressFilteraFrapw7X | UnorderedSetOfBlockIdZXK9XY8A | Slot | UnorderedSetOfDatastoreEntryInputBdlngHsZ | UnorderedSetOfSlotn0BdrHhh | UnorderedSetOfStringDoaGddGADvj0XlFa | EventFilter | ObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75Fq | Pagination | UnorderedSetOfPrivateKeyG69QLiLP | UnorderedSetOfStringBBdNk2Kup3WUWKiM | StringUJarsTOs | UnorderedSetOfStringOGpKXaCP4RgV7KAw | UnorderedSetOfOperationInput9XcIbRG1 | ApiRequest | Integer2AHOqbcQ | UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS | UnorderedSetOfAddressInfoCm3Tm6FQ | UnorderedSetOfStringUJarsTOsGY6FcFnU | UnorderedSetOfBlockInfowrpyYBUS | Block | UnorderedSetOfCliqueeS9LyMHx | UnorderedSetOfDatastoreEntryOutputhcgFMMvn | UnorderedSetOfUnorderedSetOfTransferQEyQHpyLoFgVJgXU | UnorderedSetOfEndorsementInfowrpyYBUS | UnorderedSetOfSCOutputEventHwhiOmzE | UnorderedSetOfGraphIntervalwrpyYBUS | UnorderedSetOfOperationInfoMdPofISE | UnorderedSetOfStakerX7P278VS | NodeStatus | AlwaysFalse | UnorderedSetOfIpAddressWpGgzO6M | PubkeySig | UnorderedSetOfOperationId5TxbV4NZ | PagedVecStaker | UnorderedSetOfBlockParentxrssVm84 | Version | BlockInfo | WrappedHeader | FilledBlockInfo | Operation | BooleanVyG3AETh;
-export type ExecuteReadOnlyBytecode = (ReadOnlyBytecodeExecution: UnorderedSetOfReadOnlyBytecodeExecutionK4Ht8Zdn) => Promise<UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS>;
-export type ExecuteReadOnlyCall = (ReadOnlyCall: UnorderedSetOfReadOnlyCallm6DMxyzd) => Promise<UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS>;
-export type GetAddresses = (address: UnorderedSetOfAddressjJsnATCO) => Promise<UnorderedSetOfAddressInfoCm3Tm6FQ>;
-export type GetAddressesBytecode = (addressFilter: UnorderedSetOfAddressFilteraFrapw7X) => Promise<UnorderedSetOfStringUJarsTOsGY6FcFnU>;
-export type GetBlocks = (blockId: UnorderedSetOfBlockIdZXK9XY8A) => Promise<UnorderedSetOfBlockInfowrpyYBUS>;
+export type AnyOfUnorderedSetOfReadOnlyBytecodeExecutionZbvNyXvDUnorderedSetOfReadOnlyCallOGx8T3IxUnorderedSetOfAddressjJsnATCOAddressListUnorderedSetOfBlockIdZXK9XY8ASlotUnorderedSetOfDatastoreEntryInputLrTgdYH8UnorderedSetOfSlotwrpyYBUSUnorderedSetOfEndorsementIdqnHAk5M0EventFilterObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75FqUnorderedSetOfOperationId5TxbV4NZPaginationUnorderedSetOfPrivateKeyG69QLiLPIpAddressListIpAddressListIpAddressListUnorderedSetOfStringDoaGddGADvj0XlFaIpAddressListIpAddressListIpAddressListIpAddressListIpAddressListUnorderedSetOfAddressjJsnATCOBytesUnorderedSetOfIpAddressiIc9WbOiIpAddressListIpAddressListUnorderedSetOfOperationInputx51DfMZXApiRequestInteger2AHOqbcQInteger2AHOqbcQInteger2AHOqbcQInteger2AHOqbcQUnorderedSetOfExecuteReadOnlyResponsewrpyYBUSUnorderedSetOfExecuteReadOnlyResponsewrpyYBUSUnorderedSetOfAddressInfowrpyYBUSBytecodeListUnorderedSetOfBlockInfowrpyYBUSBlockUnorderedSetOfCliqueeS9LyMHxUnorderedSetOfDatastoreEntryOutputgBhWTzxIUnorderedSetOfUnorderedSetOfTransferReceiptzpyvh8AYeEDRSdp7UnorderedSetOfEndorsementInfowrpyYBUSOutputEventsUnorderedSetOfGraphIntervalwrpyYBUSUnorderedSetOfOperationInfowrpyYBUSUnorderedSetOfStakerdplIH7J8NodeStatusAlwaysFalseUnorderedSetOfAddressjJsnATCOAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseIpAddressListIpAddressListAlwaysFalseIpAddressListAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalsePubkeySigAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseUnorderedSetOfOperationId5TxbV4NZPagedVecStakerUnorderedSetOfBlockParentwrpyYBUSVersionBlockInfoWrappedHeaderFilledBlockInfoOperationBooleanVyG3AEThBooleanVyG3AEThBooleanVyG3AEThBooleanVyG3AETh = UnorderedSetOfReadOnlyBytecodeExecutionZbvNyXvD | UnorderedSetOfReadOnlyCallOGx8T3Ix | UnorderedSetOfAddressjJsnATCO | AddressList | UnorderedSetOfBlockIdZXK9XY8A | Slot | UnorderedSetOfDatastoreEntryInputLrTgdYH8 | UnorderedSetOfSlotwrpyYBUS | UnorderedSetOfEndorsementIdqnHAk5M0 | EventFilter | ObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75Fq | UnorderedSetOfOperationId5TxbV4NZ | Pagination | UnorderedSetOfPrivateKeyG69QLiLP | IpAddressList | UnorderedSetOfStringDoaGddGADvj0XlFa | Bytes | UnorderedSetOfIpAddressiIc9WbOi | UnorderedSetOfOperationInputx51DfMZX | ApiRequest | Integer2AHOqbcQ | UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS | UnorderedSetOfAddressInfowrpyYBUS | BytecodeList | UnorderedSetOfBlockInfowrpyYBUS | Block | UnorderedSetOfCliqueeS9LyMHx | UnorderedSetOfDatastoreEntryOutputgBhWTzxI | UnorderedSetOfUnorderedSetOfTransferReceiptzpyvh8AYeEDRSdp7 | UnorderedSetOfEndorsementInfowrpyYBUS | OutputEvents | UnorderedSetOfGraphIntervalwrpyYBUS | UnorderedSetOfOperationInfowrpyYBUS | UnorderedSetOfStakerdplIH7J8 | NodeStatus | AlwaysFalse | PubkeySig | PagedVecStaker | UnorderedSetOfBlockParentwrpyYBUS | Version | BlockInfo | WrappedHeader | FilledBlockInfo | Operation | BooleanVyG3AETh;
+export type ExecuteReadOnlyBytecode = (ReadOnlyBytecodeExecution: UnorderedSetOfReadOnlyBytecodeExecutionZbvNyXvD) => Promise<UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS>;
+export type ExecuteReadOnlyCall = (ReadOnlyCall: UnorderedSetOfReadOnlyCallOGx8T3Ix) => Promise<UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS>;
+export type GetAddresses = (address: UnorderedSetOfAddressjJsnATCO) => Promise<UnorderedSetOfAddressInfowrpyYBUS>;
+export type GetAddressesBytecode = (addressFilter: AddressList) => Promise<BytecodeList>;
+export type GetBlocks = (blockIds: UnorderedSetOfBlockIdZXK9XY8A) => Promise<UnorderedSetOfBlockInfowrpyYBUS>;
 export type GetBlockcliqueBlockBySlot = (slot: Slot) => Promise<Block>;
 export type GetCliques = () => Promise<UnorderedSetOfCliqueeS9LyMHx>;
-export type GetDatastoreEntries = (DatastoreEntryInputs: UnorderedSetOfDatastoreEntryInputBdlngHsZ) => Promise<UnorderedSetOfDatastoreEntryOutputhcgFMMvn>;
-export type GetSlotsTransfers = (slots: UnorderedSetOfSlotn0BdrHhh) => Promise<UnorderedSetOfUnorderedSetOfTransferQEyQHpyLoFgVJgXU>;
-export type GetEndorsements = (endorsementId: UnorderedSetOfStringDoaGddGADvj0XlFa) => Promise<UnorderedSetOfEndorsementInfowrpyYBUS>;
-export type GetFilteredScOutputEvent = (EventFilter: EventFilter) => Promise<UnorderedSetOfSCOutputEventHwhiOmzE>;
+export type GetDatastoreEntries = (DatastoreEntryInputs: UnorderedSetOfDatastoreEntryInputLrTgdYH8) => Promise<UnorderedSetOfDatastoreEntryOutputgBhWTzxI>;
+export type GetSlotsTransfers = (slots: UnorderedSetOfSlotwrpyYBUS) => Promise<UnorderedSetOfUnorderedSetOfTransferReceiptzpyvh8AYeEDRSdp7>;
+export type GetEndorsements = (endorsementId: UnorderedSetOfEndorsementIdqnHAk5M0) => Promise<UnorderedSetOfEndorsementInfowrpyYBUS>;
+export type GetFilteredScOutputEvent = (EventFilter: EventFilter) => Promise<OutputEvents>;
 export type GetGraphInterval = (TimeInterval: ObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75Fq) => Promise<UnorderedSetOfGraphIntervalwrpyYBUS>;
-export type GetOperations = (operationId: UnorderedSetOfStringDoaGddGADvj0XlFa) => Promise<UnorderedSetOfOperationInfoMdPofISE>;
-export type GetStakers = (PageRequest: Pagination) => Promise<UnorderedSetOfStakerX7P278VS>;
+export type GetOperations = (operationId: UnorderedSetOfOperationId5TxbV4NZ) => Promise<UnorderedSetOfOperationInfowrpyYBUS>;
+export type GetStakers = (PageRequest: Pagination) => Promise<UnorderedSetOfStakerdplIH7J8>;
 export type GetStatus = () => Promise<NodeStatus>;
 export type AddStakingSecretKeys = (SecretKeys: UnorderedSetOfPrivateKeyG69QLiLP) => Promise<AlwaysFalse>;
 export type GetStakingAddresses = () => Promise<UnorderedSetOfAddressjJsnATCO>;
-export type NodeAddToBootstrapBlacklist = (ip: UnorderedSetOfStringBBdNk2Kup3WUWKiM) => Promise<AlwaysFalse>;
-export type NodeAddToBootstrapWhitelist = (ip: UnorderedSetOfStringBBdNk2Kup3WUWKiM) => Promise<AlwaysFalse>;
-export type NodeAddToPeersWhitelist = (ip: UnorderedSetOfStringBBdNk2Kup3WUWKiM) => Promise<AlwaysFalse>;
+export type NodeAddToBootstrapBlacklist = (ip: IpAddressList) => Promise<AlwaysFalse>;
+export type NodeAddToBootstrapWhitelist = (ip: IpAddressList) => Promise<AlwaysFalse>;
+export type NodeAddToPeersWhitelist = (ip: IpAddressList) => Promise<AlwaysFalse>;
 export type NodeBanById = (id: UnorderedSetOfStringDoaGddGADvj0XlFa) => Promise<AlwaysFalse>;
-export type NodeBanByIp = (ip: UnorderedSetOfStringDoaGddGADvj0XlFa) => Promise<AlwaysFalse>;
-export type NodeBootstrapBlacklist = () => Promise<UnorderedSetOfIpAddressWpGgzO6M>;
-export type NodeBootstrapWhitelist = () => Promise<UnorderedSetOfIpAddressWpGgzO6M>;
+export type NodeBanByIp = (ip: IpAddressList) => Promise<AlwaysFalse>;
+export type NodeBootstrapBlacklist = () => Promise<IpAddressList>;
+export type NodeBootstrapWhitelist = () => Promise<IpAddressList>;
 export type NodeBootstrapWhitelistAllowAll = () => Promise<AlwaysFalse>;
-export type NodePeersWhitelist = () => Promise<UnorderedSetOfIpAddressWpGgzO6M>;
-export type NodeRemoveFromBootstrapBlacklist = (ip: UnorderedSetOfStringBBdNk2Kup3WUWKiM) => Promise<AlwaysFalse>;
-export type NodeRemoveFromBootstrapWhitelist = (ip: UnorderedSetOfStringBBdNk2Kup3WUWKiM) => Promise<AlwaysFalse>;
-export type NodeRemoveFromPeersWhitelist = (ip: UnorderedSetOfStringBBdNk2Kup3WUWKiM) => Promise<AlwaysFalse>;
-export type NodeRemoveFromWhitelist = (ip: UnorderedSetOfStringBBdNk2Kup3WUWKiM) => Promise<AlwaysFalse>;
+export type NodePeersWhitelist = () => Promise<IpAddressList>;
+export type NodeRemoveFromBootstrapBlacklist = (ip: IpAddressList) => Promise<AlwaysFalse>;
+export type NodeRemoveFromBootstrapWhitelist = (ip: IpAddressList) => Promise<AlwaysFalse>;
+export type NodeRemoveFromPeersWhitelist = (ip: IpAddressList) => Promise<AlwaysFalse>;
+export type NodeRemoveFromWhitelist = (ip: IpAddressList) => Promise<AlwaysFalse>;
 export type RemoveStakingAddresses = (addresses: UnorderedSetOfAddressjJsnATCO) => Promise<AlwaysFalse>;
-export type NodeSignMessage = (message: StringUJarsTOs) => Promise<PubkeySig>;
+export type NodeSignMessage = (message: Bytes) => Promise<PubkeySig>;
 export type StopNode = () => Promise<AlwaysFalse>;
-export type NodeUnbanById = (id: UnorderedSetOfStringBBdNk2Kup3WUWKiM) => Promise<AlwaysFalse>;
-export type NodeUnbanByIp = (ip: UnorderedSetOfStringBBdNk2Kup3WUWKiM) => Promise<AlwaysFalse>;
-export type NodeWhitelist = (ip: UnorderedSetOfStringOGpKXaCP4RgV7KAw) => Promise<AlwaysFalse>;
-export type SendOperations = (OperationInput: UnorderedSetOfOperationInput9XcIbRG1) => Promise<UnorderedSetOfOperationId5TxbV4NZ>;
+export type NodeUnbanById = (id: UnorderedSetOfIpAddressiIc9WbOi) => Promise<AlwaysFalse>;
+export type NodeUnbanByIp = (ip: IpAddressList) => Promise<AlwaysFalse>;
+export type NodeWhitelist = (ip: IpAddressList) => Promise<AlwaysFalse>;
+export type SendOperations = (OperationInput: UnorderedSetOfOperationInputx51DfMZX) => Promise<UnorderedSetOfOperationId5TxbV4NZ>;
 export type GetLargestStakers = (ApiRequest: ApiRequest) => Promise<PagedVecStaker>;
-export type GetNextBlockBestParents = () => Promise<UnorderedSetOfBlockParentxrssVm84>;
+export type GetNextBlockBestParents = () => Promise<UnorderedSetOfBlockParentwrpyYBUS>;
 export type GetVersion = () => Promise<Version>;
 export type SubscribeNewBlocks = () => Promise<BlockInfo>;
 export type SubscribeNewBlocksHeaders = () => Promise<WrappedHeader>;

--- a/src/generated/index.ts
+++ b/src/generated/index.ts
@@ -1,1 +1,2 @@
 export * from "./deployer-bytecode"
+export * as rpcTypes from "./client-types"

--- a/src/operation/operation.ts
+++ b/src/operation/operation.ts
@@ -1,5 +1,5 @@
 import { Args, ArrayTypes } from '../basicElements'
-import { SCEvent } from '../client'
+import { rpcTypes as t } from '../generated'
 import { Provider } from '../provider'
 import { rawEventDecode } from '../utils'
 import { OperationStatus } from './types'
@@ -91,7 +91,7 @@ export class Operation {
    *
    * @returns The events of the operation.
    */
-  async getFinalEvents(): Promise<SCEvent[]> {
+  async getFinalEvents(): Promise<t.OutputEvents> {
     if ((await this.waitFinalExecution()) === OperationStatus.NotFound) {
       return Promise.reject(new Error('Operation not found'))
     }
@@ -104,7 +104,7 @@ export class Operation {
    *
    * @returns The speculative events of the operation.
    */
-  async getSpeculativeEvents(): Promise<SCEvent[]> {
+  async getSpeculativeEvents(): Promise<t.OutputEvents> {
     if ((await this.waitSpeculativeExecution()) === OperationStatus.NotFound) {
       return Promise.reject(new Error('Operation not found'))
     }

--- a/src/operation/operationManager.ts
+++ b/src/operation/operationManager.ts
@@ -36,7 +36,7 @@ export class OperationManager {
    * @returns A byte array representing the serialized operation.
    */
   static serialize(operation: OperationDetails): Uint8Array {
-    const components = [
+    const components: Uint8Array[] = [
       unsigned.encode(operation.fee),
       varint.encode(operation.expirePeriod),
       varint.encode(operation.type),
@@ -60,7 +60,7 @@ export class OperationManager {
         components.push(unsigned.encode(operation.coins))
         components.push(Address.fromString(operation.address).toBytes())
         components.push(varint.encode(operation.func.length))
-        components.push(Buffer.from(operation.func))
+        components.push(new TextEncoder().encode(operation.func))
         components.push(varint.encode(operation.parameter.length))
         components.push(operation.parameter)
         break
@@ -81,19 +81,17 @@ export class OperationManager {
 
         // length prefixed key-value pairs encoding
         for (const [key, value] of operation.datastore) {
-          const keyBytes = Buffer.from(key)
-          const keyLen = unsigned.encode(U64.fromNumber(keyBytes.length))
-          const valueBytes = Buffer.from(value)
-          const valueLen = unsigned.encode(U64.fromNumber(valueBytes.length))
-          components.push(keyLen, keyBytes, valueLen, valueBytes)
+          const keyLen = unsigned.encode(U64.fromNumber(key.length))
+          const valueLen = unsigned.encode(U64.fromNumber(value.length))
+          components.push(keyLen, key, valueLen, value)
         }
         break
       default:
         throw new Error('Operation type not supported')
     }
 
-    return Uint8Array.from(
-      components.flatMap((component) => Array.from(component))
+    return new Uint8Array(
+      components.reduce((acc, curr) => [...acc, ...curr], [])
     )
   }
 

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -1,4 +1,4 @@
-import { Address, EventFilter, Network, SCEvent, SmartContract } from '..'
+import { Address, EventFilter, Network, SmartContract } from '..'
 import { Mas } from '../basicElements/mas'
 import { Operation, OperationOptions, OperationStatus } from '../operation'
 import {
@@ -11,6 +11,7 @@ import {
   ExecuteScParams,
   SignOptions,
 } from './'
+import { rpcTypes as t } from '../generated'
 
 /**
  * Defines the expected structure for a provider.
@@ -44,7 +45,7 @@ export type Provider = {
   executeSC(params: ExecuteScParams): Promise<Operation>
   deploySC(params: DeploySCParams): Promise<SmartContract>
   getOperationStatus(opId: string): Promise<OperationStatus>
-  getEvents(filter: EventFilter): Promise<SCEvent[]>
+  getEvents(filter: EventFilter): Promise<t.OutputEvents>
   getNodeStatus(): Promise<NodeStatusInfo>
 
   /** Storage */

--- a/src/provider/types.ts
+++ b/src/provider/types.ts
@@ -1,7 +1,7 @@
 import { Args } from '../basicElements'
 import { Mas } from '../basicElements/mas'
 import { U64_t } from '../basicElements/serializers/number/u64'
-import { SCEvent, Slot } from '../client'
+import { rpcTypes as t } from '../generated'
 
 export type SignOptions = {
   description?: string
@@ -51,7 +51,7 @@ export type ReadSCData = {
   value: Uint8Array
   info: {
     error?: string
-    events: SCEvent[]
+    events: t.OutputEvents
     gasCost: number
   }
 }
@@ -71,13 +71,13 @@ export type NodeStatusInfo = {
   currentTime: number
   currentCycleTime: number
   nextCycleTime: number
-  lastSlot: Slot
-  nextSlot: Slot
+  lastSlot: t.Slot
+  nextSlot: t.Slot
   networkStats: NetworkStats
   nodeId: string
   nodeIp?: null | string
-  poolStats: PoolStats
-  version: Version
+  poolStats: number[]
+  version: string
   executionStats: ExecutionStats
   chainId: number
   minimalFees?: string
@@ -96,8 +96,6 @@ export type Config = {
   threadCount: number
 }
 
-export type ConnectedNodes = Record<string, unknown>
-
 export type ConsensusStats = {
   cliqueCount: number
   endTimespan: number
@@ -114,15 +112,11 @@ export type NetworkStats = {
   outConnectionCount: number
 }
 
-export type PoolStats = number[]
-
-export type Version = string
-
 export type ExecutionStats = {
   timeWindowStart: number
   timeWindowEnd: number
   finalBlockCount: number
   finalExecutedOperationsCount: number
-  activeCursor: Slot
-  finalCursor: Slot
+  activeCursor: t.Slot
+  finalCursor: t.Slot
 }

--- a/src/provider/web3Provider/web3Provider.ts
+++ b/src/provider/web3Provider/web3Provider.ts
@@ -17,9 +17,9 @@ import {
   Network,
   NetworkName,
   PublicApiUrl,
-  SCEvent,
   SmartContract,
 } from '../..'
+import { rpcTypes as t } from '../../generated'
 import { Mas } from '../../basicElements/mas'
 import {
   Operation,
@@ -223,7 +223,7 @@ export class Web3Provider extends SCProvider implements Provider {
     return this.client.getOperationStatus(opId)
   }
 
-  public async getEvents(filter: EventFilter): Promise<SCEvent[]> {
+  public async getEvents(filter: EventFilter): Promise<t.OutputEvents> {
     return this.client.getEvents(filter)
   }
 

--- a/test/generated/client-types-ti.ts
+++ b/test/generated/client-types-ti.ts
@@ -4,107 +4,93 @@
 import * as t from "ts-interface-checker";
 // tslint:disable:object-literal-key-quotes
 
-export const NumberPsns2WbD = t.name("number");
+export const GasAmount = t.name("number");
 
 export const Integer2AHOqbcQ = t.name("number");
 
-export const UnorderedSetOfInteger2AHOqbcQjNvs9B0Z = t.array("Integer2AHOqbcQ");
-
-export const Address = t.name("string");
-
-export const UnorderedSetOfInteger2AHOqbcQtXvTMhya = t.array("Integer2AHOqbcQ");
-
-export const BooleanHNwwo80P = t.name("boolean");
-
-export const NumberZ1JdLCIz = t.name("number");
-
-export const NumberSnYk3VhE = t.name("number");
-
-export const ReadOnlyBytecodeExecution = t.iface([], {
-  "max_gas": "NumberPsns2WbD",
-  "bytecode": "UnorderedSetOfInteger2AHOqbcQjNvs9B0Z",
-  "address": t.opt("Address"),
-  "operation_datastore": t.opt("UnorderedSetOfInteger2AHOqbcQtXvTMhya"),
-  "is_final": t.opt("BooleanHNwwo80P"),
-  "coins": t.opt("NumberZ1JdLCIz"),
-  "fee": t.opt("NumberSnYk3VhE"),
-});
-
-export const StringYvGZTlwQ = t.name("string");
-
-export const StringBtBJC5Iw = t.name("string");
-
-export const UnorderedSetOfInteger2AHOqbcQzYHdsLoW = t.array("Integer2AHOqbcQ");
+export const Bytes = t.array("Integer2AHOqbcQ");
 
 export const NullQu0Arl1F = t.name("null");
 
-export const StringDoaGddGA = t.name("string");
+export const Address = t.name("string");
 
-export const OneOfNullQu0Arl1FStringDoaGddGAHzYKhN99 = t.union("NullQu0Arl1F", "StringDoaGddGA");
+export const AddressOption = t.union("NullQu0Arl1F", "Address");
 
-export const OneOfNullQu0Arl1FStringDoaGddGAEUSQB1KK = t.union("NullQu0Arl1F", "StringDoaGddGA");
+export const UnorderedSetOfInteger2AHOqbcQarZIQlOy = t.array("Integer2AHOqbcQ");
 
-export const OneOfNullQu0Arl1FStringDoaGddGANOhzhrxe = t.union("NullQu0Arl1F", "StringDoaGddGA");
+export const OperationDatastore = t.union("NullQu0Arl1F", "UnorderedSetOfInteger2AHOqbcQarZIQlOy");
 
-export const ReadOnlyCall = t.iface([], {
-  "max_gas": "NumberPsns2WbD",
-  "target_address": "StringYvGZTlwQ",
-  "target_function": "StringBtBJC5Iw",
-  "parameter": "UnorderedSetOfInteger2AHOqbcQzYHdsLoW",
-  "caller_address": "OneOfNullQu0Arl1FStringDoaGddGAHzYKhN99",
-  "coins": "OneOfNullQu0Arl1FStringDoaGddGAEUSQB1KK",
-  "fee": "OneOfNullQu0Arl1FStringDoaGddGANOhzhrxe",
+export const Amount = t.name("string");
+
+export const AmountOption = t.union("NullQu0Arl1F", "Amount");
+
+export const ReadOnlyBytecodeExecution = t.iface([], {
+  "max_gas": "GasAmount",
+  "bytecode": "Bytes",
+  "address": t.opt("AddressOption"),
+  "operation_datastore": t.opt("OperationDatastore"),
+  "fee": t.opt("AmountOption"),
 });
 
-export const Boolean7Xei3MDX = t.name("boolean");
+export const TargetFunction = t.name("string");
+
+export const SCCallParams = t.array("Integer2AHOqbcQ");
+
+export const ReadOnlyCall = t.iface([], {
+  "max_gas": "GasAmount",
+  "target_address": "Address",
+  "target_function": "TargetFunction",
+  "parameter": "SCCallParams",
+  "caller_address": "AddressOption",
+  "coins": "AmountOption",
+  "fee": "AmountOption",
+});
+
+export const IsFinal = t.name("boolean");
 
 export const AddressFilter = t.iface([], {
   "address": t.opt("Address"),
-  "is_final": t.opt("Boolean7Xei3MDX"),
+  "is_final": t.opt("IsFinal"),
 });
 
 export const BlockId = t.name("string");
 
-export const NumberHo1ClIqD = t.name("number");
+export const Period = t.name("number");
 
-export const UnorderedSetOfInteger2AHOqbcQBha3UJIJ = t.array("Integer2AHOqbcQ");
+export const Thread = t.name("number");
 
 export const DatastoreEntryInput = t.iface([], {
   "address": "Address",
-  "key": "UnorderedSetOfInteger2AHOqbcQBha3UJIJ",
+  "key": "Bytes",
 });
 
 export const Slot = t.iface([], {
-  "period": "NumberHo1ClIqD",
-  "thread": "NumberHo1ClIqD",
+  "period": "Period",
+  "thread": "Thread",
 });
 
-export const String5J7NQ8B1 = t.name("string");
+export const EndorsementId = t.name("string");
 
-export const StringCc6XlKeq = t.name("string");
+export const OperationId = t.name("string");
 
-export const StringUcQL9QGN = t.name("string");
+export const Error = t.name("boolean");
 
-export const BooleanObf9WMA0 = t.name("boolean");
-
-export const BooleanAXlyTrPe = t.name("boolean");
+export const NumberHo1ClIqD = t.name("number");
 
 export const PrivateKey = t.name("string");
 
-export const StringBBdNk2Ku = t.name("string");
+export const IpAddress = t.name("string");
 
-export const StringOGpKXaCP = t.name("string");
+export const StringDoaGddGA = t.name("string");
 
 export const PublicKey = t.name("string");
 
 export const Signature = t.name("string");
 
-export const UnorderedSetOfInteger2AHOqbcQarZIQlOy = t.array("Integer2AHOqbcQ");
-
 export const OperationInput = t.iface([], {
   "creator_public_key": "PublicKey",
   "signature": "Signature",
-  "serialized_content": "UnorderedSetOfInteger2AHOqbcQarZIQlOy",
+  "serialized_content": "Bytes",
 });
 
 export const Pagination = t.iface([], {
@@ -112,55 +98,38 @@ export const Pagination = t.iface([], {
   "offset": "NumberHo1ClIqD",
 });
 
-export const ExecuteAt = t.iface([], {
-  "period": "NumberHo1ClIqD",
-  "thread": "NumberHo1ClIqD",
-});
-
-export const StringUJarsTOs = t.name("string");
-
-export const UnorderedSetOfStringUJarsTOsgviiNMvH = t.array("StringUJarsTOs");
-
 export const StringOz2F8Z2Y = t.name("string");
 
 export const ReadOnlyResult = t.iface([], {
-  "Ok": t.opt("UnorderedSetOfStringUJarsTOsgviiNMvH"),
+  "Ok": t.opt("Bytes"),
   "Error": t.opt("StringOz2F8Z2Y"),
 });
 
-export const StringBt9L6T1F = t.name("string");
+export const EventData = t.name("string");
 
-export const BooleanQYH7IQYB = t.name("boolean");
+export const IsReadonly = t.name("boolean");
 
-export const UnorderedSetOfAddressqhKJr2Tw = t.array("Address");
+export const AddressStack = t.array("Address");
 
-export const NumberHGt16B6Y = t.name("number");
-
-export const OperationId = t.name("string");
-
-export const BooleanSPcYqJj2 = t.name("boolean");
-
-export const BooleanIqtEc7R0 = t.name("boolean");
+export const IndexInSlot = t.name("number");
 
 export const EventExecutionContext = t.iface([], {
   "slot": "Slot",
   "block": t.opt("BlockId"),
-  "read_only": "BooleanQYH7IQYB",
-  "call_stack": "UnorderedSetOfAddressqhKJr2Tw",
-  "index_in_slot": "NumberHGt16B6Y",
+  "read_only": "IsReadonly",
+  "call_stack": "AddressStack",
+  "index_in_slot": "IndexInSlot",
   "origin_operation_id": t.opt("OperationId"),
-  "is_final": "BooleanSPcYqJj2",
-  "is_error": t.opt("BooleanIqtEc7R0"),
+  "is_final": "IsFinal",
+  "is_error": t.opt("Error"),
 });
 
 export const SCOutputEvent = t.iface([], {
-  "data": "StringBt9L6T1F",
+  "data": "EventData",
   "context": "EventExecutionContext",
 });
 
-export const UnorderedSetOfSCOutputEventHwhiOmzE = t.array("SCOutputEvent");
-
-export const NumberAIaYfWME = t.name("number");
+export const OutputEvents = t.array("SCOutputEvent");
 
 export const ObjectD93Z4FAG = t.iface([], {
   [t.indexKey]: "any",
@@ -196,100 +165,80 @@ export const StateChanges = t.iface([], {
 });
 
 export const ExecuteReadOnlyResponse = t.iface([], {
-  "executed_at": "ExecuteAt",
+  "executed_at": "Slot",
   "result": "ReadOnlyResult",
-  "output_events": "UnorderedSetOfSCOutputEventHwhiOmzE",
-  "gas_cost": "NumberAIaYfWME",
+  "output_events": "OutputEvents",
+  "gas_cost": "GasAmount",
   "state_changes": "StateChanges",
 });
 
-export const NumberSYJcvZVm = t.name("number");
+export const RollAmount = t.name("number");
 
-export const StringFFlpWNJb = t.name("string");
+export const DatastoreKeys = t.array("Bytes");
 
-export const NumberPAAsFK4N = t.name("number");
-
-export const UnorderedSetOfNumberHo1ClIqDAokMKuEf = t.array("NumberHo1ClIqD");
-
-export const UnorderedSetOfUnorderedSetOfNumberHo1ClIqDAokMKuEfIixaMtvV = t.array("UnorderedSetOfNumberHo1ClIqDAokMKuEf");
-
-export const StringSZbUM3UB = t.name("string");
-
-export const NumberUycrgn8X = t.name("number");
-
-export const UnorderedSetOfUnorderedSetOfNumberHo1ClIqDAokMKuEfmvpf11Qe = t.array("UnorderedSetOfNumberHo1ClIqDAokMKuEf");
-
-export const ObjectOfSlotStringDoaGddGAQZyvCcRS = t.iface([], {
+export const ObjectOfSlotAmountWrpyYBUS = t.iface([], {
   "slot": t.opt("Slot"),
-  "amount": t.opt("StringDoaGddGA"),
+  "amount": t.opt("Amount"),
   [t.indexKey]: "any",
 });
 
-export const UnorderedSetOfObjectOfSlotStringDoaGddGAQZyvCcRS732D8Bc5 = t.array("ObjectOfSlotStringDoaGddGAQZyvCcRS");
+export const UnorderedSetOfObjectOfSlotAmountWrpyYBUSwrpyYBUS = t.array("ObjectOfSlotAmountWrpyYBUS");
 
-export const UnorderedSetOfSlotpnXhUhWs = t.array("Slot");
+export const UnorderedSetOfSlotwrpyYBUS = t.array("Slot");
 
-export const ObjectOfSlotNumberHo1ClIqDMPMjgxrm = t.iface([], {
+export const ObjectOfSlotNumberHo1ClIqDWrpyYBUS = t.iface([], {
   "slot": t.opt("Slot"),
   "index": t.opt("NumberHo1ClIqD"),
   [t.indexKey]: "any",
 });
 
-export const UnorderedSetOfObjectOfSlotNumberHo1ClIqDMPMjgxrm06Ae306Q = t.array("ObjectOfSlotNumberHo1ClIqDMPMjgxrm");
+export const UnorderedSetOfObjectOfSlotNumberHo1ClIqDWrpyYBUSwrpyYBUS = t.array("ObjectOfSlotNumberHo1ClIqDWrpyYBUS");
 
-export const UnorderedSetOfBlockIdpdDCfi0P = t.array("BlockId");
+export const UnorderedSetOfBlockIdwrpyYBUS = t.array("BlockId");
 
-export const UnorderedSetOfOperationId971EzIER = t.array("OperationId");
+export const UnorderedSetOfOperationIdwrpyYBUS = t.array("OperationId");
 
-export const EndorsementId = t.name("string");
+export const UnorderedSetOfEndorsementIdwrpyYBUS = t.array("EndorsementId");
 
-export const UnorderedSetOfEndorsementIdNN27ZC1J = t.array("EndorsementId");
-
-export const BooleanVyG3AETh = t.name("boolean");
-
-export const OneOfNullQu0Arl1FNumberHo1ClIqDKWtQwzS8 = t.union("NullQu0Arl1F", "NumberHo1ClIqD");
+export const OneOfRollAmountNullQu0Arl1FGg9ZJg6R = t.union("NullQu0Arl1F", "RollAmount");
 
 export const ExecutionAddressCycleInfo = t.iface([], {
   "cycle": "NumberHo1ClIqD",
-  "is_final": "BooleanVyG3AETh",
+  "is_final": "IsFinal",
   "ok_count": "NumberHo1ClIqD",
   "nok_count": "NumberHo1ClIqD",
-  "active_rolls": t.opt("OneOfNullQu0Arl1FNumberHo1ClIqDKWtQwzS8"),
+  "active_rolls": t.opt("OneOfRollAmountNullQu0Arl1FGg9ZJg6R"),
 });
 
-export const UnorderedSetOfExecutionAddressCycleInfo8D3STgcL = t.array("ExecutionAddressCycleInfo");
+export const UnorderedSetOfExecutionAddressCycleInfowrpyYBUS = t.array("ExecutionAddressCycleInfo");
 
 export const AddressInfo = t.iface([], {
   "address": "Address",
-  "thread": "NumberSYJcvZVm",
-  "final_balance": "StringFFlpWNJb",
-  "final_roll_count": "NumberPAAsFK4N",
-  "final_datastore_keys": "UnorderedSetOfUnorderedSetOfNumberHo1ClIqDAokMKuEfIixaMtvV",
-  "candidate_balance": "StringSZbUM3UB",
-  "candidate_roll_count": "NumberUycrgn8X",
-  "candidate_datastore_keys": "UnorderedSetOfUnorderedSetOfNumberHo1ClIqDAokMKuEfmvpf11Qe",
-  "deferred_credits": "UnorderedSetOfObjectOfSlotStringDoaGddGAQZyvCcRS732D8Bc5",
-  "next_block_draws": "UnorderedSetOfSlotpnXhUhWs",
-  "next_endorsement_draws": "UnorderedSetOfObjectOfSlotNumberHo1ClIqDMPMjgxrm06Ae306Q",
-  "created_blocks": "UnorderedSetOfBlockIdpdDCfi0P",
-  "created_operations": "UnorderedSetOfOperationId971EzIER",
-  "created_endorsements": "UnorderedSetOfEndorsementIdNN27ZC1J",
-  "cycle_infos": "UnorderedSetOfExecutionAddressCycleInfo8D3STgcL",
+  "thread": "Thread",
+  "final_balance": "Amount",
+  "final_roll_count": "RollAmount",
+  "final_datastore_keys": "DatastoreKeys",
+  "candidate_balance": "Amount",
+  "candidate_roll_count": "RollAmount",
+  "candidate_datastore_keys": "DatastoreKeys",
+  "deferred_credits": "UnorderedSetOfObjectOfSlotAmountWrpyYBUSwrpyYBUS",
+  "next_block_draws": "UnorderedSetOfSlotwrpyYBUS",
+  "next_endorsement_draws": "UnorderedSetOfObjectOfSlotNumberHo1ClIqDWrpyYBUSwrpyYBUS",
+  "created_blocks": "UnorderedSetOfBlockIdwrpyYBUS",
+  "created_operations": "UnorderedSetOfOperationIdwrpyYBUS",
+  "created_endorsements": "UnorderedSetOfEndorsementIdwrpyYBUS",
+  "cycle_infos": "UnorderedSetOfExecutionAddressCycleInfowrpyYBUS",
 });
 
-export const BooleanZxUVUy6M = t.name("boolean");
+export const IsCandidate = t.name("boolean");
 
-export const BooleanMazVJcyf = t.name("boolean");
+export const IsDiscarded = t.name("boolean");
 
-export const BooleanHJvzO9WE = t.name("boolean");
-
-export const BooleanHjqkwJfo = t.name("boolean");
+export const InBlockClique = t.name("boolean");
 
 export const NumberTbrodUsH = t.name("number");
 
 export const OneOfNullQu0Arl1FNumberHo1ClIqD4U4GpKJM = t.union("NullQu0Arl1F", "NumberHo1ClIqD");
-
-export const UnorderedSetOfStringDoaGddGADvj0XlFa = t.array("StringDoaGddGA");
 
 export const EndorsementContent = t.iface([], {
   "slot": "Slot",
@@ -297,50 +246,50 @@ export const EndorsementContent = t.iface([], {
   "endorsed_block": "BlockId",
 });
 
-export const ObjectOfStringDoaGddGAEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUS = t.iface([], {
+export const ObjectOfSignatureEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUS = t.iface([], {
   "content": t.opt("EndorsementContent"),
-  "signature": t.opt("StringDoaGddGA"),
+  "signature": t.opt("Signature"),
   "content_creator_pub_key": t.opt("PublicKey"),
   "content_creator_address": t.opt("Address"),
   "id": t.opt("EndorsementId"),
   [t.indexKey]: "any",
 });
 
-export const UnorderedSetOfObjectOfStringDoaGddGAEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUSwrpyYBUS = t.array("ObjectOfStringDoaGddGAEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUS");
+export const UnorderedSetOfObjectOfSignatureEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUSwrpyYBUS = t.array("ObjectOfSignatureEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUS");
 
-export const ObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUS = t.iface([], {
-  "public_key": t.opt("StringDoaGddGA"),
-  "slot": t.opt("Integer2AHOqbcQ"),
+export const ObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUS = t.iface([], {
+  "public_key": t.opt("PublicKey"),
+  "slot": t.opt("Slot"),
   "index": t.opt("Integer2AHOqbcQ"),
   "hash_1": t.opt("StringDoaGddGA"),
   "hash_2": t.opt("StringDoaGddGA"),
-  "signature_1": t.opt("StringDoaGddGA"),
-  "signature_2": t.opt("StringDoaGddGA"),
+  "signature_1": t.opt("Signature"),
+  "signature_2": t.opt("Signature"),
   [t.indexKey]: "any",
 });
 
-export const ObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUS = t.iface([], {
-  "public_key": t.opt("StringDoaGddGA"),
-  "slot": t.opt("Integer2AHOqbcQ"),
+export const ObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUS = t.iface([], {
+  "public_key": t.opt("PublicKey"),
+  "slot": t.opt("Slot"),
   "hash_1": t.opt("StringDoaGddGA"),
   "hash_2": t.opt("StringDoaGddGA"),
-  "signature_1": t.opt("StringDoaGddGA"),
-  "signature_2": t.opt("StringDoaGddGA"),
+  "signature_1": t.opt("Signature"),
+  "signature_2": t.opt("Signature"),
   [t.indexKey]: "any",
 });
 
-export const OneOfObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUSGJLAASWC = t.union("ObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUS", "ObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUS");
+export const OneOfObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUSTKq8XnCL = t.union("ObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUS", "ObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUS");
 
-export const UnorderedSetOfOneOfObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUSGJLAASWCwrpyYBUS = t.array("OneOfObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUSGJLAASWC");
+export const UnorderedSetOfOneOfObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUSTKq8XnCLwrpyYBUS = t.array("OneOfObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUSTKq8XnCL");
 
 export const Header = t.iface([], {
   "current_version": t.opt("NumberTbrodUsH"),
   "announced_version": t.opt("OneOfNullQu0Arl1FNumberHo1ClIqD4U4GpKJM"),
   "operation_merkle_root": "StringDoaGddGA",
-  "parents": "UnorderedSetOfStringDoaGddGADvj0XlFa",
+  "parents": "UnorderedSetOfBlockIdwrpyYBUS",
   "slot": "Slot",
-  "endorsements": t.opt("UnorderedSetOfObjectOfStringDoaGddGAEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUSwrpyYBUS"),
-  "denunciations": t.opt("UnorderedSetOfOneOfObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUSGJLAASWCwrpyYBUS"),
+  "endorsements": t.opt("UnorderedSetOfObjectOfSignatureEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUSwrpyYBUS"),
+  "denunciations": t.opt("UnorderedSetOfOneOfObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUSTKq8XnCLwrpyYBUS"),
 });
 
 export const WrappedHeader = t.iface([], {
@@ -351,23 +300,21 @@ export const WrappedHeader = t.iface([], {
   "id": t.opt("BlockId"),
 });
 
-export const UnorderedSetOfStringDoaGddGAucaTsQyS = t.array("StringDoaGddGA");
-
 export const Block = t.iface([], {
   "header": "WrappedHeader",
-  "operations": "UnorderedSetOfStringDoaGddGAucaTsQyS",
+  "operations": "UnorderedSetOfOperationIdwrpyYBUS",
 });
 
 export const BlockInfoContent = t.iface([], {
-  "is_final": "BooleanZxUVUy6M",
-  "is_candidate": "BooleanMazVJcyf",
-  "is_discarded": t.opt("BooleanHJvzO9WE"),
-  "is_in_blockclique": "BooleanHjqkwJfo",
+  "is_final": "IsFinal",
+  "is_candidate": "IsCandidate",
+  "is_discarded": t.opt("IsDiscarded"),
+  "is_in_blockclique": "InBlockClique",
   "block": "Block",
 });
 
 export const BlockInfo = t.iface([], {
-  "id": "StringDoaGddGA",
+  "id": "BlockId",
   "content": t.opt("BlockInfoContent"),
 });
 
@@ -383,45 +330,33 @@ export const Clique = t.iface([], {
   "is_blockclique": "BooleanXIboFXzF",
 });
 
-export const OneOfNullQu0Arl1FUnorderedSetOfInteger2AHOqbcQarZIQlOy81SHPJsX = t.union("UnorderedSetOfInteger2AHOqbcQarZIQlOy", "NullQu0Arl1F");
-
-export const OneOfNullQu0Arl1FUnorderedSetOfInteger2AHOqbcQarZIQlOyGOQJrRPK = t.union("UnorderedSetOfInteger2AHOqbcQarZIQlOy", "NullQu0Arl1F");
+export const BytesOption = t.union("NullQu0Arl1F", "Bytes");
 
 export const DatastoreEntryOutput = t.iface([], {
-  "candidate_value": "OneOfNullQu0Arl1FUnorderedSetOfInteger2AHOqbcQarZIQlOy81SHPJsX",
-  "final_value": "OneOfNullQu0Arl1FUnorderedSetOfInteger2AHOqbcQarZIQlOyGOQJrRPK",
+  "candidate_value": "BytesOption",
+  "final_value": "BytesOption",
 });
 
-export const StringYVTrFSaQ = t.name("string");
-
-export const StringZyWeUFZ8 = t.name("string");
-
-export const IntegerCOVAu0Eq = t.name("number");
-
-export const IntegerVC2Agt39 = t.name("number");
-
-export const Object0XCk2T5H = t.iface([], {
+export const Context = t.iface([], {
   [t.indexKey]: "any",
 });
 
-export const BooleanYDqyb5Vp = t.name("boolean");
+export const IsSuccess = t.name("boolean");
 
-export const NumberV8R93Gu7 = t.name("number");
-
-export const StringUyVBK2CK = t.name("string");
-
-export const Transfer = t.iface([], {
-  "from": "StringYVTrFSaQ",
-  "to": "StringZyWeUFZ8",
-  "amount": "IntegerCOVAu0Eq",
-  "effective_amount_received": "IntegerVC2Agt39",
-  "context": "Object0XCk2T5H",
-  "succeed": "BooleanYDqyb5Vp",
-  "fee": "NumberV8R93Gu7",
-  "block_id": "StringUyVBK2CK",
+export const TransferReceipt = t.iface([], {
+  "from": "Address",
+  "to": "Address",
+  "amount": "Amount",
+  "effective_amount_received": "Amount",
+  "context": "Context",
+  "succeed": "IsSuccess",
+  "fee": "Amount",
+  "block_id": "BlockId",
 });
 
-export const UnorderedSetOfTransferQEyQHpyL = t.array("Transfer");
+export const UnorderedSetOfTransferReceiptzpyvh8AY = t.array("TransferReceipt");
+
+export const BooleanVyG3AETh = t.name("boolean");
 
 export const UnorderedSetOfBlockId7G1Sy5Qv = t.array("BlockId");
 
@@ -430,109 +365,81 @@ export const Endorsement = t.iface([], {
   "content_creator_pub_key": "PublicKey",
   "content_creator_address": t.opt("Address"),
   "id": t.opt("EndorsementId"),
-  "signature": "StringDoaGddGA",
+  "signature": "Signature",
 });
 
 export const EndorsementInfo = t.iface([], {
   "id": "EndorsementId",
   "in_pool": "BooleanVyG3AETh",
   "in_blocks": "UnorderedSetOfBlockId7G1Sy5Qv",
-  "is_final": "BooleanVyG3AETh",
+  "is_final": "IsFinal",
   "endorsement": "Endorsement",
 });
 
-export const StringVuVvWRdT = t.name("string");
+export const Stale = t.name("boolean");
 
-export const StringU8LlHDu1 = t.name("string");
-
-export const UnorderedSetOfStringDoaGddGAMZnHm9WS = t.array("StringDoaGddGA");
+export const UnorderedSetOfBlockIdNY3ZAj2A = t.array("BlockId");
 
 export const GraphInterval = t.iface([], {
-  "creator": "StringVuVvWRdT",
-  "id": "StringU8LlHDu1",
-  "is_final": "BooleanVyG3AETh",
-  "is_in_blockclique": "BooleanVyG3AETh",
-  "is_stale": "BooleanVyG3AETh",
-  "parents": "UnorderedSetOfStringDoaGddGAMZnHm9WS",
+  "creator": "PublicKey",
+  "id": "BlockId",
+  "is_final": "IsFinal",
+  "is_in_blockclique": "InBlockClique",
+  "is_stale": "Stale",
+  "parents": "UnorderedSetOfBlockIdNY3ZAj2A",
   "slot": "Slot",
 });
-
-export const StringYTemzr68 = t.name("string");
 
 export const UnorderedSetOfBlockIdyEy9Dvpn = t.array("BlockId");
 
 export const BooleanSJ3TNusg = t.name("boolean");
 
-export const OneOfBooleanVyG3AEThNullQu0Arl1FCuqCzoUJ = t.union("NullQu0Arl1F", "BooleanVyG3AETh");
+export const IsFinalOperation = t.union("NullQu0Arl1F", "IsFinal");
 
-export const NumberZoWtBk8U = t.name("number");
-
-export const StringV3754ZDT = t.name("string");
-
-export const NumberSbfeGjn7 = t.name("number");
-
-export const StringNIrlyE1J = t.name("string");
-
-export const Transaction = t.iface([], {
-  "amount": "StringNIrlyE1J",
-  "recipient_address": "StringDoaGddGA",
+export const TransactionReceipt = t.iface([], {
+  "amount": "Amount",
+  "recipient_address": "Address",
 });
 
-export const UnorderedSetOfNumberHo1ClIqDd5W02PgX = t.array("NumberHo1ClIqD");
+export const UnorderedSetOfBytes0JFPBP6Z = t.array("Bytes");
 
-export const NumberQUXtpAPK = t.name("number");
+export const DatastoreEntry = t.array("UnorderedSetOfBytes0JFPBP6Z");
 
-export const ObjectOfUnorderedSetOfInteger2AHOqbcQarZIQlOyUnorderedSetOfInteger2AHOqbcQarZIQlOyDbxIogvI = t.iface([], {
-  "entry": t.opt("UnorderedSetOfInteger2AHOqbcQarZIQlOy"),
-  "bytes": t.opt("UnorderedSetOfInteger2AHOqbcQarZIQlOy"),
-  [t.indexKey]: "any",
+export const ExecuteSCReceipt = t.iface([], {
+  "data": "Bytes",
+  "max_gas": "GasAmount",
+  "datastore": "DatastoreEntry",
 });
 
-export const Datastore = t.iface([], {
-  [t.indexKey]: "any",
-});
+export const FunctionName = t.name("string");
 
-export const ExecuteSC = t.iface([], {
-  "data": "UnorderedSetOfNumberHo1ClIqDd5W02PgX",
-  "max_gas": "NumberQUXtpAPK",
-  "datastore": "Datastore",
-});
-
-export const String7HCIMJir = t.name("string");
-
-export const StringSjIor0MV = t.name("string");
-
-export const Number5Mo1HId6 = t.name("number");
-
-export const CallSC = t.iface([], {
+export const CallSCReceipt = t.iface([], {
   "target_addr": "Address",
-  "target_func": "String7HCIMJir",
-  "param": "StringSjIor0MV",
-  "max_gas": "NumberHo1ClIqD",
-  "coins": "Number5Mo1HId6",
+  "target_func": "FunctionName",
+  "param": "SCCallParams",
+  "max_gas": "GasAmount",
+  "coins": "Amount",
 });
 
-export const NumberJdJmnq9D = t.name("number");
-
-export const RollBuy = t.iface([], {
-  "roll_count": "NumberJdJmnq9D",
+export const RollBuyReceipt = t.iface([], {
+  "roll_count": "RollAmount",
 });
 
-export const RollSell = t.iface([], {
-  "roll_count": "NumberJdJmnq9D",
+export const RollSellReceipt = t.iface([], {
+  "roll_count": "RollAmount",
 });
 
 export const OperationType = t.iface([], {
-  "Transaction": t.opt("Transaction"),
-  "ExecutSC": t.opt("ExecuteSC"),
-  "CallSC": t.opt("CallSC"),
-  "RollBuy": t.opt("RollBuy"),
-  "RollSell": t.opt("RollSell"),
+  "Transaction": t.opt("TransactionReceipt"),
+  "ExecutSC": t.opt("ExecuteSCReceipt"),
+  "CallSC": t.opt("CallSCReceipt"),
+  "RollBuy": t.opt("RollBuyReceipt"),
+  "RollSell": t.opt("RollSellReceipt"),
 });
 
 export const Operation = t.iface([], {
-  "fee": "StringV3754ZDT",
-  "expire_period": "NumberSbfeGjn7",
+  "fee": "Amount",
+  "expire_period": "Period",
   "op": "OperationType",
 });
 
@@ -547,18 +454,18 @@ export const WrappedOperation = t.iface([], {
 export const OneOfBooleanVyG3AEThNullQu0Arl1FE3Qax0Os = t.union("NullQu0Arl1F", "BooleanVyG3AETh");
 
 export const OperationInfo = t.iface([], {
-  "id": "StringYTemzr68",
+  "id": "OperationId",
   "in_blocks": "UnorderedSetOfBlockIdyEy9Dvpn",
   "in_pool": "BooleanSJ3TNusg",
-  "is_operation_final": "OneOfBooleanVyG3AEThNullQu0Arl1FCuqCzoUJ",
-  "thread": "NumberZoWtBk8U",
+  "is_operation_final": "IsFinalOperation",
+  "thread": "Thread",
   "operation": "WrappedOperation",
   "op_exec_status": t.opt("OneOfBooleanVyG3AEThNullQu0Arl1FE3Qax0Os"),
 });
 
-export const ObjectOfAddressNumberHo1ClIqDFbgdJFtJ = t.iface([], {
+export const ObjectOfAddressRollAmountUf3B9Cb5 = t.iface([], {
   "address": t.opt("Address"),
-  "active_rolls": t.opt("NumberHo1ClIqD"),
+  "active_rolls": t.opt("RollAmount"),
   [t.indexKey]: "any",
 });
 
@@ -583,21 +490,21 @@ export const Number8ImKBhpQ = t.name("number");
 export const NumberAxwlzLso = t.name("number");
 
 export const Config = t.iface([], {
-  "block_reward": "StringNIrlyE1J",
+  "block_reward": "Amount",
   "delta_f0": "Number2A9FvvYh",
   "end_timestamp": t.opt("OneOfNullQu0Arl1FNumberHo1ClIqDXysINzQy"),
   "genesis_timestamp": "NumberSgfzurLm",
   "max_block_size": t.opt("NumberUwkWWxaa"),
   "operation_validity_periods": "NumberTs6Cn6JQ",
   "periods_per_cycle": "NumberGrsxxfaH",
-  "roll_price": "StringNIrlyE1J",
+  "roll_price": "Amount",
   "t0": "Number8ImKBhpQ",
   "thread_count": "NumberAxwlzLso",
 });
 
-export const ObjectOfStringDoaGddGAStringDoaGddGAXJdFCZe6 = t.iface([], {
+export const ObjectOfStringDoaGddGAIpAddressWrpyYBUS = t.iface([], {
   "node_id": t.opt("StringDoaGddGA"),
-  "ip_address": t.opt("StringDoaGddGA"),
+  "ip_address": t.opt("IpAddress"),
   [t.indexKey]: "any",
 });
 
@@ -643,7 +550,7 @@ export const NetworkStats = t.iface([], {
 
 export const StringOFgZzVe7 = t.name("string");
 
-export const OneOfNullQu0Arl1FStringDoaGddGANsst9HIR = t.union("NullQu0Arl1F", "StringDoaGddGA");
+export const OneOfIpAddressNullQu0Arl1FXaFV5TPI = t.union("NullQu0Arl1F", "IpAddress");
 
 export const PoolStats = t.array("NumberHo1ClIqD");
 
@@ -668,21 +575,13 @@ export const ExecutionStats = t.iface([], {
 
 export const NumberBte4OVdF = t.name("number");
 
-export const StringTXHumHoA = t.name("string");
-
 export const AlwaysFalse = t.name("any");
 
-export const IpAddress = t.name("string");
+export const UnorderedSetOfStakerdplIH7J8 = t.array("Staker");
 
-export const StringTPMT1Yxd = t.name("string");
-
-export const StringXHbmHEWh = t.name("string");
-
-export const UnorderedSetOfStakerX7P278VS = t.array("Staker");
-
-export const ObjectOfNumberHo1ClIqDBlockIdHCnqqlza = t.iface([], {
+export const ObjectOfPeriodBlockIdWrpyYBUS = t.iface([], {
   "BlockId": t.opt("BlockId"),
-  "period": t.opt("NumberHo1ClIqD"),
+  "period": t.opt("Period"),
   [t.indexKey]: "any",
 });
 
@@ -690,44 +589,42 @@ export const BlockParent = t.iface([], {
   [t.indexKey]: "any",
 });
 
-export const Boolean4XbLtRCK = t.name("boolean");
-
-export const UnorderedSetOfOperationInfowrpyYBUS = t.array("OperationInfo");
+export const Operations = t.array("OperationInfo");
 
 export const FilledBlock = t.iface([], {
   "header": "WrappedHeader",
-  "operations": "UnorderedSetOfOperationInfowrpyYBUS",
+  "operations": "Operations",
 });
 
 export const FilledBlockInfoContent = t.iface([], {
-  "is_final": "BooleanZxUVUy6M",
-  "is_stale": "Boolean4XbLtRCK",
-  "is_in_blockclique": "BooleanHjqkwJfo",
+  "is_final": "IsFinal",
+  "is_stale": "Stale",
+  "is_in_blockclique": "InBlockClique",
   "block": "FilledBlock",
 });
 
-export const UnorderedSetOfReadOnlyBytecodeExecutionK4Ht8Zdn = t.array("ReadOnlyBytecodeExecution");
+export const UnorderedSetOfReadOnlyBytecodeExecutionZbvNyXvD = t.array("ReadOnlyBytecodeExecution");
 
-export const UnorderedSetOfReadOnlyCallm6DMxyzd = t.array("ReadOnlyCall");
+export const UnorderedSetOfReadOnlyCallOGx8T3Ix = t.array("ReadOnlyCall");
 
 export const UnorderedSetOfAddressjJsnATCO = t.array("Address");
 
-export const UnorderedSetOfAddressFilteraFrapw7X = t.array("AddressFilter");
+export const AddressList = t.array("AddressFilter");
 
 export const UnorderedSetOfBlockIdZXK9XY8A = t.array("BlockId");
 
-export const UnorderedSetOfDatastoreEntryInputBdlngHsZ = t.array("DatastoreEntryInput");
+export const UnorderedSetOfDatastoreEntryInputLrTgdYH8 = t.array("DatastoreEntryInput");
 
-export const UnorderedSetOfSlotn0BdrHhh = t.array("Slot");
+export const UnorderedSetOfEndorsementIdqnHAk5M0 = t.array("EndorsementId");
 
 export const EventFilter = t.iface([], {
   "start": t.opt("Slot"),
   "end": t.opt("Slot"),
-  "emitter_address": t.opt("String5J7NQ8B1"),
-  "original_caller_address": t.opt("StringCc6XlKeq"),
-  "original_operation_id": t.opt("StringUcQL9QGN"),
-  "is_final": t.opt("BooleanObf9WMA0"),
-  "is_error": t.opt("BooleanAXlyTrPe"),
+  "emitter_address": t.opt("Address"),
+  "original_caller_address": t.opt("Address"),
+  "original_operation_id": t.opt("OperationId"),
+  "is_final": t.opt("IsFinal"),
+  "is_error": t.opt("Error"),
 });
 
 export const ObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75Fq = t.iface([], {
@@ -735,13 +632,17 @@ export const ObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75Fq = t.iface([], {
   "end": t.opt("NumberHo1ClIqD"),
 });
 
+export const UnorderedSetOfOperationId5TxbV4NZ = t.array("OperationId");
+
 export const UnorderedSetOfPrivateKeyG69QLiLP = t.array("PrivateKey");
 
-export const UnorderedSetOfStringBBdNk2Kup3WUWKiM = t.array("StringBBdNk2Ku");
+export const IpAddressList = t.array("IpAddress");
 
-export const UnorderedSetOfStringOGpKXaCP4RgV7KAw = t.array("StringOGpKXaCP");
+export const UnorderedSetOfStringDoaGddGADvj0XlFa = t.array("StringDoaGddGA");
 
-export const UnorderedSetOfOperationInput9XcIbRG1 = t.array("OperationInput");
+export const UnorderedSetOfIpAddressiIc9WbOi = t.array("IpAddress");
+
+export const UnorderedSetOfOperationInputx51DfMZX = t.array("OperationInput");
 
 export const ApiRequest = t.iface([], {
   "page_request": t.opt("Pagination"),
@@ -749,23 +650,23 @@ export const ApiRequest = t.iface([], {
 
 export const UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS = t.array("ExecuteReadOnlyResponse");
 
-export const UnorderedSetOfAddressInfoCm3Tm6FQ = t.array("AddressInfo");
+export const UnorderedSetOfAddressInfowrpyYBUS = t.array("AddressInfo");
 
-export const UnorderedSetOfStringUJarsTOsGY6FcFnU = t.array("StringUJarsTOs");
+export const BytecodeList = t.array("Bytes");
 
 export const UnorderedSetOfBlockInfowrpyYBUS = t.array("BlockInfo");
 
 export const UnorderedSetOfCliqueeS9LyMHx = t.array("Clique");
 
-export const UnorderedSetOfDatastoreEntryOutputhcgFMMvn = t.array("DatastoreEntryOutput");
+export const UnorderedSetOfDatastoreEntryOutputgBhWTzxI = t.array("DatastoreEntryOutput");
 
-export const UnorderedSetOfUnorderedSetOfTransferQEyQHpyLoFgVJgXU = t.array("UnorderedSetOfTransferQEyQHpyL");
+export const UnorderedSetOfUnorderedSetOfTransferReceiptzpyvh8AYeEDRSdp7 = t.array("UnorderedSetOfTransferReceiptzpyvh8AY");
 
 export const UnorderedSetOfEndorsementInfowrpyYBUS = t.array("EndorsementInfo");
 
 export const UnorderedSetOfGraphIntervalwrpyYBUS = t.array("GraphInterval");
 
-export const UnorderedSetOfOperationInfoMdPofISE = t.array("OperationInfo");
+export const UnorderedSetOfOperationInfowrpyYBUS = t.array("OperationInfo");
 
 export const NodeStatus = t.iface([], {
   "config": "Config",
@@ -779,64 +680,60 @@ export const NodeStatus = t.iface([], {
   "network_stats": "NetworkStats",
   "next_slot": "Slot",
   "node_id": "StringOFgZzVe7",
-  "node_ip": t.opt("OneOfNullQu0Arl1FStringDoaGddGANsst9HIR"),
+  "node_ip": t.opt("OneOfIpAddressNullQu0Arl1FXaFV5TPI"),
   "pool_stats": "PoolStats",
   "version": "Version",
   "execution_stats": "ExecutionStats",
   "chain_id": "NumberBte4OVdF",
-  "minimal_fees": t.opt("StringTXHumHoA"),
+  "minimal_fees": t.opt("Amount"),
 });
-
-export const UnorderedSetOfIpAddressWpGgzO6M = t.array("IpAddress");
 
 export const PubkeySig = t.iface([], {
-  "public_key": "StringTPMT1Yxd",
-  "signature": "StringXHbmHEWh",
+  "public_key": "PublicKey",
+  "signature": "Signature",
 });
 
-export const UnorderedSetOfOperationId5TxbV4NZ = t.array("OperationId");
-
 export const PagedVecStaker = t.iface([], {
-  "content": t.opt("UnorderedSetOfStakerX7P278VS"),
+  "content": t.opt("UnorderedSetOfStakerdplIH7J8"),
   "total_count": t.opt("NumberHo1ClIqD"),
 });
 
-export const UnorderedSetOfBlockParentxrssVm84 = t.array("BlockParent");
+export const UnorderedSetOfBlockParentwrpyYBUS = t.array("BlockParent");
 
 export const FilledBlockInfo = t.iface([], {
-  "id": "StringDoaGddGA",
+  "id": "OperationId",
   "content": t.opt("FilledBlockInfoContent"),
 });
 
-export const AnyOfUnorderedSetOfReadOnlyBytecodeExecutionK4Ht8ZdnUnorderedSetOfReadOnlyCallm6DMxyzdUnorderedSetOfAddressjJsnATCOUnorderedSetOfAddressFilteraFrapw7XUnorderedSetOfBlockIdZXK9XY8ASlotUnorderedSetOfDatastoreEntryInputBdlngHsZUnorderedSetOfSlotn0BdrHhhUnorderedSetOfStringDoaGddGADvj0XlFaEventFilterObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75FqUnorderedSetOfStringDoaGddGADvj0XlFaPaginationUnorderedSetOfPrivateKeyG69QLiLPUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringDoaGddGADvj0XlFaUnorderedSetOfStringDoaGddGADvj0XlFaUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfAddressjJsnATCOStringUJarsTOsUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringOGpKXaCP4RgV7KAwUnorderedSetOfOperationInput9XcIbRG1ApiRequestInteger2AHOqbcQInteger2AHOqbcQInteger2AHOqbcQInteger2AHOqbcQUnorderedSetOfExecuteReadOnlyResponsewrpyYBUSUnorderedSetOfExecuteReadOnlyResponsewrpyYBUSUnorderedSetOfAddressInfoCm3Tm6FQUnorderedSetOfStringUJarsTOsGY6FcFnUUnorderedSetOfBlockInfowrpyYBUSBlockUnorderedSetOfCliqueeS9LyMHxUnorderedSetOfDatastoreEntryOutputhcgFMMvnUnorderedSetOfUnorderedSetOfTransferQEyQHpyLoFgVJgXUUnorderedSetOfEndorsementInfowrpyYBUSUnorderedSetOfSCOutputEventHwhiOmzEUnorderedSetOfGraphIntervalwrpyYBUSUnorderedSetOfOperationInfoMdPofISEUnorderedSetOfStakerX7P278VSNodeStatusAlwaysFalseUnorderedSetOfAddressjJsnATCOAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseUnorderedSetOfIpAddressWpGgzO6MUnorderedSetOfIpAddressWpGgzO6MAlwaysFalseUnorderedSetOfIpAddressWpGgzO6MAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalsePubkeySigAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseUnorderedSetOfOperationId5TxbV4NZPagedVecStakerUnorderedSetOfBlockParentxrssVm84VersionBlockInfoWrappedHeaderFilledBlockInfoOperationBooleanVyG3AEThBooleanVyG3AEThBooleanVyG3AEThBooleanVyG3AETh = t.union("UnorderedSetOfReadOnlyBytecodeExecutionK4Ht8Zdn", "UnorderedSetOfReadOnlyCallm6DMxyzd", "UnorderedSetOfAddressjJsnATCO", "UnorderedSetOfAddressFilteraFrapw7X", "UnorderedSetOfBlockIdZXK9XY8A", "Slot", "UnorderedSetOfDatastoreEntryInputBdlngHsZ", "UnorderedSetOfSlotn0BdrHhh", "UnorderedSetOfStringDoaGddGADvj0XlFa", "EventFilter", "ObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75Fq", "Pagination", "UnorderedSetOfPrivateKeyG69QLiLP", "UnorderedSetOfStringBBdNk2Kup3WUWKiM", "StringUJarsTOs", "UnorderedSetOfStringOGpKXaCP4RgV7KAw", "UnorderedSetOfOperationInput9XcIbRG1", "ApiRequest", "Integer2AHOqbcQ", "UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS", "UnorderedSetOfAddressInfoCm3Tm6FQ", "UnorderedSetOfStringUJarsTOsGY6FcFnU", "UnorderedSetOfBlockInfowrpyYBUS", "Block", "UnorderedSetOfCliqueeS9LyMHx", "UnorderedSetOfDatastoreEntryOutputhcgFMMvn", "UnorderedSetOfUnorderedSetOfTransferQEyQHpyLoFgVJgXU", "UnorderedSetOfEndorsementInfowrpyYBUS", "UnorderedSetOfSCOutputEventHwhiOmzE", "UnorderedSetOfGraphIntervalwrpyYBUS", "UnorderedSetOfOperationInfoMdPofISE", "UnorderedSetOfStakerX7P278VS", "NodeStatus", "AlwaysFalse", "UnorderedSetOfIpAddressWpGgzO6M", "PubkeySig", "UnorderedSetOfOperationId5TxbV4NZ", "PagedVecStaker", "UnorderedSetOfBlockParentxrssVm84", "Version", "BlockInfo", "WrappedHeader", "FilledBlockInfo", "Operation", "BooleanVyG3AETh");
+export const AnyOfUnorderedSetOfReadOnlyBytecodeExecutionZbvNyXvDUnorderedSetOfReadOnlyCallOGx8T3IxUnorderedSetOfAddressjJsnATCOAddressListUnorderedSetOfBlockIdZXK9XY8ASlotUnorderedSetOfDatastoreEntryInputLrTgdYH8UnorderedSetOfSlotwrpyYBUSUnorderedSetOfEndorsementIdqnHAk5M0EventFilterObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75FqUnorderedSetOfOperationId5TxbV4NZPaginationUnorderedSetOfPrivateKeyG69QLiLPIpAddressListIpAddressListIpAddressListUnorderedSetOfStringDoaGddGADvj0XlFaIpAddressListIpAddressListIpAddressListIpAddressListIpAddressListUnorderedSetOfAddressjJsnATCOBytesUnorderedSetOfIpAddressiIc9WbOiIpAddressListIpAddressListUnorderedSetOfOperationInputx51DfMZXApiRequestInteger2AHOqbcQInteger2AHOqbcQInteger2AHOqbcQInteger2AHOqbcQUnorderedSetOfExecuteReadOnlyResponsewrpyYBUSUnorderedSetOfExecuteReadOnlyResponsewrpyYBUSUnorderedSetOfAddressInfowrpyYBUSBytecodeListUnorderedSetOfBlockInfowrpyYBUSBlockUnorderedSetOfCliqueeS9LyMHxUnorderedSetOfDatastoreEntryOutputgBhWTzxIUnorderedSetOfUnorderedSetOfTransferReceiptzpyvh8AYeEDRSdp7UnorderedSetOfEndorsementInfowrpyYBUSOutputEventsUnorderedSetOfGraphIntervalwrpyYBUSUnorderedSetOfOperationInfowrpyYBUSUnorderedSetOfStakerdplIH7J8NodeStatusAlwaysFalseUnorderedSetOfAddressjJsnATCOAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseIpAddressListIpAddressListAlwaysFalseIpAddressListAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalsePubkeySigAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseUnorderedSetOfOperationId5TxbV4NZPagedVecStakerUnorderedSetOfBlockParentwrpyYBUSVersionBlockInfoWrappedHeaderFilledBlockInfoOperationBooleanVyG3AEThBooleanVyG3AEThBooleanVyG3AEThBooleanVyG3AETh = t.union("UnorderedSetOfReadOnlyBytecodeExecutionZbvNyXvD", "UnorderedSetOfReadOnlyCallOGx8T3Ix", "UnorderedSetOfAddressjJsnATCO", "AddressList", "UnorderedSetOfBlockIdZXK9XY8A", "Slot", "UnorderedSetOfDatastoreEntryInputLrTgdYH8", "UnorderedSetOfSlotwrpyYBUS", "UnorderedSetOfEndorsementIdqnHAk5M0", "EventFilter", "ObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75Fq", "UnorderedSetOfOperationId5TxbV4NZ", "Pagination", "UnorderedSetOfPrivateKeyG69QLiLP", "IpAddressList", "UnorderedSetOfStringDoaGddGADvj0XlFa", "Bytes", "UnorderedSetOfIpAddressiIc9WbOi", "UnorderedSetOfOperationInputx51DfMZX", "ApiRequest", "Integer2AHOqbcQ", "UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS", "UnorderedSetOfAddressInfowrpyYBUS", "BytecodeList", "UnorderedSetOfBlockInfowrpyYBUS", "Block", "UnorderedSetOfCliqueeS9LyMHx", "UnorderedSetOfDatastoreEntryOutputgBhWTzxI", "UnorderedSetOfUnorderedSetOfTransferReceiptzpyvh8AYeEDRSdp7", "UnorderedSetOfEndorsementInfowrpyYBUS", "OutputEvents", "UnorderedSetOfGraphIntervalwrpyYBUS", "UnorderedSetOfOperationInfowrpyYBUS", "UnorderedSetOfStakerdplIH7J8", "NodeStatus", "AlwaysFalse", "PubkeySig", "PagedVecStaker", "UnorderedSetOfBlockParentwrpyYBUS", "Version", "BlockInfo", "WrappedHeader", "FilledBlockInfo", "Operation", "BooleanVyG3AETh");
 
-export const ExecuteReadOnlyBytecode = t.func("UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS", t.param("ReadOnlyBytecodeExecution", "UnorderedSetOfReadOnlyBytecodeExecutionK4Ht8Zdn"));
+export const ExecuteReadOnlyBytecode = t.func("UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS", t.param("ReadOnlyBytecodeExecution", "UnorderedSetOfReadOnlyBytecodeExecutionZbvNyXvD"));
 
-export const ExecuteReadOnlyCall = t.func("UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS", t.param("ReadOnlyCall", "UnorderedSetOfReadOnlyCallm6DMxyzd"));
+export const ExecuteReadOnlyCall = t.func("UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS", t.param("ReadOnlyCall", "UnorderedSetOfReadOnlyCallOGx8T3Ix"));
 
-export const GetAddresses = t.func("UnorderedSetOfAddressInfoCm3Tm6FQ", t.param("address", "UnorderedSetOfAddressjJsnATCO"));
+export const GetAddresses = t.func("UnorderedSetOfAddressInfowrpyYBUS", t.param("address", "UnorderedSetOfAddressjJsnATCO"));
 
-export const GetAddressesBytecode = t.func("UnorderedSetOfStringUJarsTOsGY6FcFnU", t.param("addressFilter", "UnorderedSetOfAddressFilteraFrapw7X"));
+export const GetAddressesBytecode = t.func("BytecodeList", t.param("addressFilter", "AddressList"));
 
-export const GetBlocks = t.func("UnorderedSetOfBlockInfowrpyYBUS", t.param("blockId", "UnorderedSetOfBlockIdZXK9XY8A"));
+export const GetBlocks = t.func("UnorderedSetOfBlockInfowrpyYBUS", t.param("blockIds", "UnorderedSetOfBlockIdZXK9XY8A"));
 
 export const GetBlockcliqueBlockBySlot = t.func("Block", t.param("slot", "Slot"));
 
 export const GetCliques = t.func("UnorderedSetOfCliqueeS9LyMHx");
 
-export const GetDatastoreEntries = t.func("UnorderedSetOfDatastoreEntryOutputhcgFMMvn", t.param("DatastoreEntryInputs", "UnorderedSetOfDatastoreEntryInputBdlngHsZ"));
+export const GetDatastoreEntries = t.func("UnorderedSetOfDatastoreEntryOutputgBhWTzxI", t.param("DatastoreEntryInputs", "UnorderedSetOfDatastoreEntryInputLrTgdYH8"));
 
-export const GetSlotsTransfers = t.func("UnorderedSetOfUnorderedSetOfTransferQEyQHpyLoFgVJgXU", t.param("slots", "UnorderedSetOfSlotn0BdrHhh"));
+export const GetSlotsTransfers = t.func("UnorderedSetOfUnorderedSetOfTransferReceiptzpyvh8AYeEDRSdp7", t.param("slots", "UnorderedSetOfSlotwrpyYBUS"));
 
-export const GetEndorsements = t.func("UnorderedSetOfEndorsementInfowrpyYBUS", t.param("endorsementId", "UnorderedSetOfStringDoaGddGADvj0XlFa"));
+export const GetEndorsements = t.func("UnorderedSetOfEndorsementInfowrpyYBUS", t.param("endorsementId", "UnorderedSetOfEndorsementIdqnHAk5M0"));
 
-export const GetFilteredScOutputEvent = t.func("UnorderedSetOfSCOutputEventHwhiOmzE", t.param("EventFilter", "EventFilter"));
+export const GetFilteredScOutputEvent = t.func("OutputEvents", t.param("EventFilter", "EventFilter"));
 
 export const GetGraphInterval = t.func("UnorderedSetOfGraphIntervalwrpyYBUS", t.param("TimeInterval", "ObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75Fq"));
 
-export const GetOperations = t.func("UnorderedSetOfOperationInfoMdPofISE", t.param("operationId", "UnorderedSetOfStringDoaGddGADvj0XlFa"));
+export const GetOperations = t.func("UnorderedSetOfOperationInfowrpyYBUS", t.param("operationId", "UnorderedSetOfOperationId5TxbV4NZ"));
 
-export const GetStakers = t.func("UnorderedSetOfStakerX7P278VS", t.param("PageRequest", "Pagination"));
+export const GetStakers = t.func("UnorderedSetOfStakerdplIH7J8", t.param("PageRequest", "Pagination"));
 
 export const GetStatus = t.func("NodeStatus");
 
@@ -844,49 +741,49 @@ export const AddStakingSecretKeys = t.func("AlwaysFalse", t.param("SecretKeys", 
 
 export const GetStakingAddresses = t.func("UnorderedSetOfAddressjJsnATCO");
 
-export const NodeAddToBootstrapBlacklist = t.func("AlwaysFalse", t.param("ip", "UnorderedSetOfStringBBdNk2Kup3WUWKiM"));
+export const NodeAddToBootstrapBlacklist = t.func("AlwaysFalse", t.param("ip", "IpAddressList"));
 
-export const NodeAddToBootstrapWhitelist = t.func("AlwaysFalse", t.param("ip", "UnorderedSetOfStringBBdNk2Kup3WUWKiM"));
+export const NodeAddToBootstrapWhitelist = t.func("AlwaysFalse", t.param("ip", "IpAddressList"));
 
-export const NodeAddToPeersWhitelist = t.func("AlwaysFalse", t.param("ip", "UnorderedSetOfStringBBdNk2Kup3WUWKiM"));
+export const NodeAddToPeersWhitelist = t.func("AlwaysFalse", t.param("ip", "IpAddressList"));
 
 export const NodeBanById = t.func("AlwaysFalse", t.param("id", "UnorderedSetOfStringDoaGddGADvj0XlFa"));
 
-export const NodeBanByIp = t.func("AlwaysFalse", t.param("ip", "UnorderedSetOfStringDoaGddGADvj0XlFa"));
+export const NodeBanByIp = t.func("AlwaysFalse", t.param("ip", "IpAddressList"));
 
-export const NodeBootstrapBlacklist = t.func("UnorderedSetOfIpAddressWpGgzO6M");
+export const NodeBootstrapBlacklist = t.func("IpAddressList");
 
-export const NodeBootstrapWhitelist = t.func("UnorderedSetOfIpAddressWpGgzO6M");
+export const NodeBootstrapWhitelist = t.func("IpAddressList");
 
 export const NodeBootstrapWhitelistAllowAll = t.func("AlwaysFalse");
 
-export const NodePeersWhitelist = t.func("UnorderedSetOfIpAddressWpGgzO6M");
+export const NodePeersWhitelist = t.func("IpAddressList");
 
-export const NodeRemoveFromBootstrapBlacklist = t.func("AlwaysFalse", t.param("ip", "UnorderedSetOfStringBBdNk2Kup3WUWKiM"));
+export const NodeRemoveFromBootstrapBlacklist = t.func("AlwaysFalse", t.param("ip", "IpAddressList"));
 
-export const NodeRemoveFromBootstrapWhitelist = t.func("AlwaysFalse", t.param("ip", "UnorderedSetOfStringBBdNk2Kup3WUWKiM"));
+export const NodeRemoveFromBootstrapWhitelist = t.func("AlwaysFalse", t.param("ip", "IpAddressList"));
 
-export const NodeRemoveFromPeersWhitelist = t.func("AlwaysFalse", t.param("ip", "UnorderedSetOfStringBBdNk2Kup3WUWKiM"));
+export const NodeRemoveFromPeersWhitelist = t.func("AlwaysFalse", t.param("ip", "IpAddressList"));
 
-export const NodeRemoveFromWhitelist = t.func("AlwaysFalse", t.param("ip", "UnorderedSetOfStringBBdNk2Kup3WUWKiM"));
+export const NodeRemoveFromWhitelist = t.func("AlwaysFalse", t.param("ip", "IpAddressList"));
 
 export const RemoveStakingAddresses = t.func("AlwaysFalse", t.param("addresses", "UnorderedSetOfAddressjJsnATCO"));
 
-export const NodeSignMessage = t.func("PubkeySig", t.param("message", "StringUJarsTOs"));
+export const NodeSignMessage = t.func("PubkeySig", t.param("message", "Bytes"));
 
 export const StopNode = t.func("AlwaysFalse");
 
-export const NodeUnbanById = t.func("AlwaysFalse", t.param("id", "UnorderedSetOfStringBBdNk2Kup3WUWKiM"));
+export const NodeUnbanById = t.func("AlwaysFalse", t.param("id", "UnorderedSetOfIpAddressiIc9WbOi"));
 
-export const NodeUnbanByIp = t.func("AlwaysFalse", t.param("ip", "UnorderedSetOfStringBBdNk2Kup3WUWKiM"));
+export const NodeUnbanByIp = t.func("AlwaysFalse", t.param("ip", "IpAddressList"));
 
-export const NodeWhitelist = t.func("AlwaysFalse", t.param("ip", "UnorderedSetOfStringOGpKXaCP4RgV7KAw"));
+export const NodeWhitelist = t.func("AlwaysFalse", t.param("ip", "IpAddressList"));
 
-export const SendOperations = t.func("UnorderedSetOfOperationId5TxbV4NZ", t.param("OperationInput", "UnorderedSetOfOperationInput9XcIbRG1"));
+export const SendOperations = t.func("UnorderedSetOfOperationId5TxbV4NZ", t.param("OperationInput", "UnorderedSetOfOperationInputx51DfMZX"));
 
 export const GetLargestStakers = t.func("PagedVecStaker", t.param("ApiRequest", "ApiRequest"));
 
-export const GetNextBlockBestParents = t.func("UnorderedSetOfBlockParentxrssVm84");
+export const GetNextBlockBestParents = t.func("UnorderedSetOfBlockParentwrpyYBUS");
 
 export const GetVersion = t.func("Version");
 
@@ -907,60 +804,47 @@ export const UnsubscribeNewFilledBlocks = t.func("BooleanVyG3AETh", t.param("sub
 export const UnsubscribeNewOperations = t.func("BooleanVyG3AETh", t.param("subscriptionId", "Integer2AHOqbcQ"));
 
 const exportedTypeSuite: t.ITypeSuite = {
-  NumberPsns2WbD,
+  GasAmount,
   Integer2AHOqbcQ,
-  UnorderedSetOfInteger2AHOqbcQjNvs9B0Z,
-  Address,
-  UnorderedSetOfInteger2AHOqbcQtXvTMhya,
-  BooleanHNwwo80P,
-  NumberZ1JdLCIz,
-  NumberSnYk3VhE,
-  ReadOnlyBytecodeExecution,
-  StringYvGZTlwQ,
-  StringBtBJC5Iw,
-  UnorderedSetOfInteger2AHOqbcQzYHdsLoW,
+  Bytes,
   NullQu0Arl1F,
-  StringDoaGddGA,
-  OneOfNullQu0Arl1FStringDoaGddGAHzYKhN99,
-  OneOfNullQu0Arl1FStringDoaGddGAEUSQB1KK,
-  OneOfNullQu0Arl1FStringDoaGddGANOhzhrxe,
+  Address,
+  AddressOption,
+  UnorderedSetOfInteger2AHOqbcQarZIQlOy,
+  OperationDatastore,
+  Amount,
+  AmountOption,
+  ReadOnlyBytecodeExecution,
+  TargetFunction,
+  SCCallParams,
   ReadOnlyCall,
-  Boolean7Xei3MDX,
+  IsFinal,
   AddressFilter,
   BlockId,
-  NumberHo1ClIqD,
-  UnorderedSetOfInteger2AHOqbcQBha3UJIJ,
+  Period,
+  Thread,
   DatastoreEntryInput,
   Slot,
-  String5J7NQ8B1,
-  StringCc6XlKeq,
-  StringUcQL9QGN,
-  BooleanObf9WMA0,
-  BooleanAXlyTrPe,
+  EndorsementId,
+  OperationId,
+  Error,
+  NumberHo1ClIqD,
   PrivateKey,
-  StringBBdNk2Ku,
-  StringOGpKXaCP,
+  IpAddress,
+  StringDoaGddGA,
   PublicKey,
   Signature,
-  UnorderedSetOfInteger2AHOqbcQarZIQlOy,
   OperationInput,
   Pagination,
-  ExecuteAt,
-  StringUJarsTOs,
-  UnorderedSetOfStringUJarsTOsgviiNMvH,
   StringOz2F8Z2Y,
   ReadOnlyResult,
-  StringBt9L6T1F,
-  BooleanQYH7IQYB,
-  UnorderedSetOfAddressqhKJr2Tw,
-  NumberHGt16B6Y,
-  OperationId,
-  BooleanSPcYqJj2,
-  BooleanIqtEc7R0,
+  EventData,
+  IsReadonly,
+  AddressStack,
+  IndexInSlot,
   EventExecutionContext,
   SCOutputEvent,
-  UnorderedSetOfSCOutputEventHwhiOmzE,
-  NumberAIaYfWME,
+  OutputEvents,
   ObjectD93Z4FAG,
   ObjectHAgrRKSz,
   UnorderedSetOfObjectHAgrRKSz46QV1Tyv,
@@ -970,45 +854,34 @@ const exportedTypeSuite: t.ITypeSuite = {
   StringIytPJwYq,
   StateChanges,
   ExecuteReadOnlyResponse,
-  NumberSYJcvZVm,
-  StringFFlpWNJb,
-  NumberPAAsFK4N,
-  UnorderedSetOfNumberHo1ClIqDAokMKuEf,
-  UnorderedSetOfUnorderedSetOfNumberHo1ClIqDAokMKuEfIixaMtvV,
-  StringSZbUM3UB,
-  NumberUycrgn8X,
-  UnorderedSetOfUnorderedSetOfNumberHo1ClIqDAokMKuEfmvpf11Qe,
-  ObjectOfSlotStringDoaGddGAQZyvCcRS,
-  UnorderedSetOfObjectOfSlotStringDoaGddGAQZyvCcRS732D8Bc5,
-  UnorderedSetOfSlotpnXhUhWs,
-  ObjectOfSlotNumberHo1ClIqDMPMjgxrm,
-  UnorderedSetOfObjectOfSlotNumberHo1ClIqDMPMjgxrm06Ae306Q,
-  UnorderedSetOfBlockIdpdDCfi0P,
-  UnorderedSetOfOperationId971EzIER,
-  EndorsementId,
-  UnorderedSetOfEndorsementIdNN27ZC1J,
-  BooleanVyG3AETh,
-  OneOfNullQu0Arl1FNumberHo1ClIqDKWtQwzS8,
+  RollAmount,
+  DatastoreKeys,
+  ObjectOfSlotAmountWrpyYBUS,
+  UnorderedSetOfObjectOfSlotAmountWrpyYBUSwrpyYBUS,
+  UnorderedSetOfSlotwrpyYBUS,
+  ObjectOfSlotNumberHo1ClIqDWrpyYBUS,
+  UnorderedSetOfObjectOfSlotNumberHo1ClIqDWrpyYBUSwrpyYBUS,
+  UnorderedSetOfBlockIdwrpyYBUS,
+  UnorderedSetOfOperationIdwrpyYBUS,
+  UnorderedSetOfEndorsementIdwrpyYBUS,
+  OneOfRollAmountNullQu0Arl1FGg9ZJg6R,
   ExecutionAddressCycleInfo,
-  UnorderedSetOfExecutionAddressCycleInfo8D3STgcL,
+  UnorderedSetOfExecutionAddressCycleInfowrpyYBUS,
   AddressInfo,
-  BooleanZxUVUy6M,
-  BooleanMazVJcyf,
-  BooleanHJvzO9WE,
-  BooleanHjqkwJfo,
+  IsCandidate,
+  IsDiscarded,
+  InBlockClique,
   NumberTbrodUsH,
   OneOfNullQu0Arl1FNumberHo1ClIqD4U4GpKJM,
-  UnorderedSetOfStringDoaGddGADvj0XlFa,
   EndorsementContent,
-  ObjectOfStringDoaGddGAEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUS,
-  UnorderedSetOfObjectOfStringDoaGddGAEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUSwrpyYBUS,
-  ObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUS,
-  ObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUS,
-  OneOfObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUSGJLAASWC,
-  UnorderedSetOfOneOfObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfInteger2AHOqbcQStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAStringDoaGddGAWrpyYBUSGJLAASWCwrpyYBUS,
+  ObjectOfSignatureEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUS,
+  UnorderedSetOfObjectOfSignatureEndorsementIdPublicKeyAddressEndorsementContentWrpyYBUSwrpyYBUS,
+  ObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUS,
+  ObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUS,
+  OneOfObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUSTKq8XnCL,
+  UnorderedSetOfOneOfObjectOfSlotSignatureSignaturePublicKeyInteger2AHOqbcQStringDoaGddGAStringDoaGddGAWrpyYBUSObjectOfSlotSignatureSignaturePublicKeyStringDoaGddGAStringDoaGddGAWrpyYBUSTKq8XnCLwrpyYBUS,
   Header,
   WrappedHeader,
-  UnorderedSetOfStringDoaGddGAucaTsQyS,
   Block,
   BlockInfoContent,
   BlockInfo,
@@ -1016,53 +889,36 @@ const exportedTypeSuite: t.ITypeSuite = {
   Number7BVjpZ2Z,
   BooleanXIboFXzF,
   Clique,
-  OneOfNullQu0Arl1FUnorderedSetOfInteger2AHOqbcQarZIQlOy81SHPJsX,
-  OneOfNullQu0Arl1FUnorderedSetOfInteger2AHOqbcQarZIQlOyGOQJrRPK,
+  BytesOption,
   DatastoreEntryOutput,
-  StringYVTrFSaQ,
-  StringZyWeUFZ8,
-  IntegerCOVAu0Eq,
-  IntegerVC2Agt39,
-  Object0XCk2T5H,
-  BooleanYDqyb5Vp,
-  NumberV8R93Gu7,
-  StringUyVBK2CK,
-  Transfer,
-  UnorderedSetOfTransferQEyQHpyL,
+  Context,
+  IsSuccess,
+  TransferReceipt,
+  UnorderedSetOfTransferReceiptzpyvh8AY,
+  BooleanVyG3AETh,
   UnorderedSetOfBlockId7G1Sy5Qv,
   Endorsement,
   EndorsementInfo,
-  StringVuVvWRdT,
-  StringU8LlHDu1,
-  UnorderedSetOfStringDoaGddGAMZnHm9WS,
+  Stale,
+  UnorderedSetOfBlockIdNY3ZAj2A,
   GraphInterval,
-  StringYTemzr68,
   UnorderedSetOfBlockIdyEy9Dvpn,
   BooleanSJ3TNusg,
-  OneOfBooleanVyG3AEThNullQu0Arl1FCuqCzoUJ,
-  NumberZoWtBk8U,
-  StringV3754ZDT,
-  NumberSbfeGjn7,
-  StringNIrlyE1J,
-  Transaction,
-  UnorderedSetOfNumberHo1ClIqDd5W02PgX,
-  NumberQUXtpAPK,
-  ObjectOfUnorderedSetOfInteger2AHOqbcQarZIQlOyUnorderedSetOfInteger2AHOqbcQarZIQlOyDbxIogvI,
-  Datastore,
-  ExecuteSC,
-  String7HCIMJir,
-  StringSjIor0MV,
-  Number5Mo1HId6,
-  CallSC,
-  NumberJdJmnq9D,
-  RollBuy,
-  RollSell,
+  IsFinalOperation,
+  TransactionReceipt,
+  UnorderedSetOfBytes0JFPBP6Z,
+  DatastoreEntry,
+  ExecuteSCReceipt,
+  FunctionName,
+  CallSCReceipt,
+  RollBuyReceipt,
+  RollSellReceipt,
   OperationType,
   Operation,
   WrappedOperation,
   OneOfBooleanVyG3AEThNullQu0Arl1FE3Qax0Os,
   OperationInfo,
-  ObjectOfAddressNumberHo1ClIqDFbgdJFtJ,
+  ObjectOfAddressRollAmountUf3B9Cb5,
   Staker,
   Number2A9FvvYh,
   OneOfNullQu0Arl1FNumberHo1ClIqDXysINzQy,
@@ -1073,7 +929,7 @@ const exportedTypeSuite: t.ITypeSuite = {
   Number8ImKBhpQ,
   NumberAxwlzLso,
   Config,
-  ObjectOfStringDoaGddGAStringDoaGddGAXJdFCZe6,
+  ObjectOfStringDoaGddGAIpAddressWrpyYBUS,
   ConnectedNodes,
   NumberLpoULYcx,
   ConsensusStats,
@@ -1088,7 +944,7 @@ const exportedTypeSuite: t.ITypeSuite = {
   NumberXuleKeT9,
   NetworkStats,
   StringOFgZzVe7,
-  OneOfNullQu0Arl1FStringDoaGddGANsst9HIR,
+  OneOfIpAddressNullQu0Arl1FXaFV5TPI,
   PoolStats,
   Version,
   NumberDk8ZmyGi,
@@ -1097,50 +953,45 @@ const exportedTypeSuite: t.ITypeSuite = {
   NumberJ4Dz6P30,
   ExecutionStats,
   NumberBte4OVdF,
-  StringTXHumHoA,
   AlwaysFalse,
-  IpAddress,
-  StringTPMT1Yxd,
-  StringXHbmHEWh,
-  UnorderedSetOfStakerX7P278VS,
-  ObjectOfNumberHo1ClIqDBlockIdHCnqqlza,
+  UnorderedSetOfStakerdplIH7J8,
+  ObjectOfPeriodBlockIdWrpyYBUS,
   BlockParent,
-  Boolean4XbLtRCK,
-  UnorderedSetOfOperationInfowrpyYBUS,
+  Operations,
   FilledBlock,
   FilledBlockInfoContent,
-  UnorderedSetOfReadOnlyBytecodeExecutionK4Ht8Zdn,
-  UnorderedSetOfReadOnlyCallm6DMxyzd,
+  UnorderedSetOfReadOnlyBytecodeExecutionZbvNyXvD,
+  UnorderedSetOfReadOnlyCallOGx8T3Ix,
   UnorderedSetOfAddressjJsnATCO,
-  UnorderedSetOfAddressFilteraFrapw7X,
+  AddressList,
   UnorderedSetOfBlockIdZXK9XY8A,
-  UnorderedSetOfDatastoreEntryInputBdlngHsZ,
-  UnorderedSetOfSlotn0BdrHhh,
+  UnorderedSetOfDatastoreEntryInputLrTgdYH8,
+  UnorderedSetOfEndorsementIdqnHAk5M0,
   EventFilter,
   ObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75Fq,
+  UnorderedSetOfOperationId5TxbV4NZ,
   UnorderedSetOfPrivateKeyG69QLiLP,
-  UnorderedSetOfStringBBdNk2Kup3WUWKiM,
-  UnorderedSetOfStringOGpKXaCP4RgV7KAw,
-  UnorderedSetOfOperationInput9XcIbRG1,
+  IpAddressList,
+  UnorderedSetOfStringDoaGddGADvj0XlFa,
+  UnorderedSetOfIpAddressiIc9WbOi,
+  UnorderedSetOfOperationInputx51DfMZX,
   ApiRequest,
   UnorderedSetOfExecuteReadOnlyResponsewrpyYBUS,
-  UnorderedSetOfAddressInfoCm3Tm6FQ,
-  UnorderedSetOfStringUJarsTOsGY6FcFnU,
+  UnorderedSetOfAddressInfowrpyYBUS,
+  BytecodeList,
   UnorderedSetOfBlockInfowrpyYBUS,
   UnorderedSetOfCliqueeS9LyMHx,
-  UnorderedSetOfDatastoreEntryOutputhcgFMMvn,
-  UnorderedSetOfUnorderedSetOfTransferQEyQHpyLoFgVJgXU,
+  UnorderedSetOfDatastoreEntryOutputgBhWTzxI,
+  UnorderedSetOfUnorderedSetOfTransferReceiptzpyvh8AYeEDRSdp7,
   UnorderedSetOfEndorsementInfowrpyYBUS,
   UnorderedSetOfGraphIntervalwrpyYBUS,
-  UnorderedSetOfOperationInfoMdPofISE,
+  UnorderedSetOfOperationInfowrpyYBUS,
   NodeStatus,
-  UnorderedSetOfIpAddressWpGgzO6M,
   PubkeySig,
-  UnorderedSetOfOperationId5TxbV4NZ,
   PagedVecStaker,
-  UnorderedSetOfBlockParentxrssVm84,
+  UnorderedSetOfBlockParentwrpyYBUS,
   FilledBlockInfo,
-  AnyOfUnorderedSetOfReadOnlyBytecodeExecutionK4Ht8ZdnUnorderedSetOfReadOnlyCallm6DMxyzdUnorderedSetOfAddressjJsnATCOUnorderedSetOfAddressFilteraFrapw7XUnorderedSetOfBlockIdZXK9XY8ASlotUnorderedSetOfDatastoreEntryInputBdlngHsZUnorderedSetOfSlotn0BdrHhhUnorderedSetOfStringDoaGddGADvj0XlFaEventFilterObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75FqUnorderedSetOfStringDoaGddGADvj0XlFaPaginationUnorderedSetOfPrivateKeyG69QLiLPUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringDoaGddGADvj0XlFaUnorderedSetOfStringDoaGddGADvj0XlFaUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfAddressjJsnATCOStringUJarsTOsUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringBBdNk2Kup3WUWKiMUnorderedSetOfStringOGpKXaCP4RgV7KAwUnorderedSetOfOperationInput9XcIbRG1ApiRequestInteger2AHOqbcQInteger2AHOqbcQInteger2AHOqbcQInteger2AHOqbcQUnorderedSetOfExecuteReadOnlyResponsewrpyYBUSUnorderedSetOfExecuteReadOnlyResponsewrpyYBUSUnorderedSetOfAddressInfoCm3Tm6FQUnorderedSetOfStringUJarsTOsGY6FcFnUUnorderedSetOfBlockInfowrpyYBUSBlockUnorderedSetOfCliqueeS9LyMHxUnorderedSetOfDatastoreEntryOutputhcgFMMvnUnorderedSetOfUnorderedSetOfTransferQEyQHpyLoFgVJgXUUnorderedSetOfEndorsementInfowrpyYBUSUnorderedSetOfSCOutputEventHwhiOmzEUnorderedSetOfGraphIntervalwrpyYBUSUnorderedSetOfOperationInfoMdPofISEUnorderedSetOfStakerX7P278VSNodeStatusAlwaysFalseUnorderedSetOfAddressjJsnATCOAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseUnorderedSetOfIpAddressWpGgzO6MUnorderedSetOfIpAddressWpGgzO6MAlwaysFalseUnorderedSetOfIpAddressWpGgzO6MAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalsePubkeySigAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseUnorderedSetOfOperationId5TxbV4NZPagedVecStakerUnorderedSetOfBlockParentxrssVm84VersionBlockInfoWrappedHeaderFilledBlockInfoOperationBooleanVyG3AEThBooleanVyG3AEThBooleanVyG3AEThBooleanVyG3AETh,
+  AnyOfUnorderedSetOfReadOnlyBytecodeExecutionZbvNyXvDUnorderedSetOfReadOnlyCallOGx8T3IxUnorderedSetOfAddressjJsnATCOAddressListUnorderedSetOfBlockIdZXK9XY8ASlotUnorderedSetOfDatastoreEntryInputLrTgdYH8UnorderedSetOfSlotwrpyYBUSUnorderedSetOfEndorsementIdqnHAk5M0EventFilterObjectOfNumberHo1ClIqDNumberHo1ClIqDTmeT75FqUnorderedSetOfOperationId5TxbV4NZPaginationUnorderedSetOfPrivateKeyG69QLiLPIpAddressListIpAddressListIpAddressListUnorderedSetOfStringDoaGddGADvj0XlFaIpAddressListIpAddressListIpAddressListIpAddressListIpAddressListUnorderedSetOfAddressjJsnATCOBytesUnorderedSetOfIpAddressiIc9WbOiIpAddressListIpAddressListUnorderedSetOfOperationInputx51DfMZXApiRequestInteger2AHOqbcQInteger2AHOqbcQInteger2AHOqbcQInteger2AHOqbcQUnorderedSetOfExecuteReadOnlyResponsewrpyYBUSUnorderedSetOfExecuteReadOnlyResponsewrpyYBUSUnorderedSetOfAddressInfowrpyYBUSBytecodeListUnorderedSetOfBlockInfowrpyYBUSBlockUnorderedSetOfCliqueeS9LyMHxUnorderedSetOfDatastoreEntryOutputgBhWTzxIUnorderedSetOfUnorderedSetOfTransferReceiptzpyvh8AYeEDRSdp7UnorderedSetOfEndorsementInfowrpyYBUSOutputEventsUnorderedSetOfGraphIntervalwrpyYBUSUnorderedSetOfOperationInfowrpyYBUSUnorderedSetOfStakerdplIH7J8NodeStatusAlwaysFalseUnorderedSetOfAddressjJsnATCOAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseIpAddressListIpAddressListAlwaysFalseIpAddressListAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalsePubkeySigAlwaysFalseAlwaysFalseAlwaysFalseAlwaysFalseUnorderedSetOfOperationId5TxbV4NZPagedVecStakerUnorderedSetOfBlockParentwrpyYBUSVersionBlockInfoWrappedHeaderFilledBlockInfoOperationBooleanVyG3AEThBooleanVyG3AEThBooleanVyG3AEThBooleanVyG3AETh,
   ExecuteReadOnlyBytecode,
   ExecuteReadOnlyCall,
   GetAddresses,

--- a/test/integration/events.spec.ts
+++ b/test/integration/events.spec.ts
@@ -1,5 +1,6 @@
-import { EventFilter, EventPoller, SCEvent } from '../../src'
+import { EventFilter, EventPoller } from '../../src'
 import { MRC20 } from '../../src/contracts-wrappers'
+import { OutputEvents } from '../../src/generated/client-types'
 import { provider } from './setup'
 import waitForExpect from 'wait-for-expect'
 
@@ -21,7 +22,7 @@ describe('SC Event tests', () => {
     )
     await operation.waitSpeculativeExecution()
 
-    let events: SCEvent[] = []
+    let events: OutputEvents = []
 
     const filter = {
       smartContractAddress: USDC,
@@ -50,7 +51,7 @@ describe('SC Event tests', () => {
     )
     await operation.waitSpeculativeExecution()
 
-    let events: SCEvent[] = []
+    let events: OutputEvents = []
 
     const filter: EventFilter = {
       operationId: operation.id,
@@ -77,7 +78,7 @@ describe('SC Event tests', () => {
     )
     await operation.waitSpeculativeExecution()
 
-    let events: SCEvent[] = []
+    let events: OutputEvents = []
 
     const filter: EventFilter = {
       operationId: operation.id,

--- a/test/integration/publicAPI.spec.ts
+++ b/test/integration/publicAPI.spec.ts
@@ -10,6 +10,7 @@ import { EventFilter, PublicAPI } from '../../src/client'
 import { MAX_GAS_CALL } from '../../src/smartContracts'
 import { bytesToStr, strToBytes } from '../../src/basicElements'
 import { provider } from './setup'
+import { DEPLOYER_BYTECODE } from '../../src'
 
 const {
   NodeStatus,
@@ -201,19 +202,19 @@ describe('client tests', () => {
 
   test('executeReadOnlyBytecode', async () => {
     const response = await client.executeReadOnlyBytecode({
-      max_gas: 100000,
-      bytecode: [65, 66],
+      bytecode: Array.from(DEPLOYER_BYTECODE),
       address: TEST_USER,
+      max_gas: Number(MAX_GAS_CALL),
     })
     ExecuteReadOnlyResponse.strictCheck(response)
   })
 
   test('executeMultipleReadOnlyBytecode', async () => {
     const req = {
-      max_gas: 100000,
-      bytecode: [65, 66],
+      bytecode: Array.from(DEPLOYER_BYTECODE),
       address: TEST_USER,
-    } as ReadOnlyBytecodeExecution
+      max_gas: Number(MAX_GAS_CALL),
+    }
     const responses = await client.executeMultipleReadOnlyBytecode([req, req])
     expect(responses).toHaveLength(2)
   })
@@ -255,17 +256,14 @@ describe('client tests', () => {
 
   test('executeMultipleReadOnlyCall', async () => {
     let arg = {
-      max_gas: 1000000,
-      target_address: TEST_USER,
-      target_function: 'hello',
-      parameter: [],
-      caller_address: null,
-      coins: null,
-      fee: null,
-    } as ReadOnlyCall
+      target: TEST_CONTRACT,
+      func: 'hello',
+      parameter: new Uint8Array(),
+      caller: TEST_USER,
+    }
     const responses = await client.executeMultipleReadOnlyCall([arg, arg])
     expect(responses).toHaveLength(2)
-    ExecuteReadOnlyResponse.strictCheck(responses[0])
-    ExecuteReadOnlyResponse.strictCheck(responses[1])
+    expect(bytesToStr(responses[0].value)).toBe(`Hello, ${NAME_VAL}!`)
+    expect(bytesToStr(responses[1].value)).toBe(`Hello, ${NAME_VAL}!`)
   })
 })

--- a/test/unit/mock/blockchainClient.mock.ts
+++ b/test/unit/mock/blockchainClient.mock.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { PublicAPI, SCEvent } from '../../../src/client'
-import { NodeStatus } from '../../../src/generated/client-types'
+import { PublicAPI } from '../../../src/client'
+import { NodeStatus, OutputEvents } from '../../../src/generated/client-types'
 
 export const blockchainClientMock = {
   sendOperation: jest.fn().mockResolvedValue('operationId'),
   fetchPeriod: jest.fn().mockResolvedValue(1),
   getOperationStatus: jest.fn(),
   getBalance: jest.fn().mockResolvedValue(123_456_789n),
-  getEvents: jest.fn().mockResolvedValue([] as SCEvent[]),
+  getEvents: jest.fn().mockResolvedValue([] as OutputEvents),
   getChainId: jest.fn().mockResolvedValue(1n),
   getMinimalFee: jest.fn().mockResolvedValue(100_000n),
   executeReadOnlyCall: jest.fn().mockResolvedValue({

--- a/test/unit/operation.spec.ts
+++ b/test/unit/operation.spec.ts
@@ -1,9 +1,11 @@
 import { Operation } from '../../src/operation'
-import { EventExecutionContext } from '../../src/generated/client-types'
+import {
+  EventExecutionContext,
+  OutputEvents,
+} from '../../src/generated/client-types'
 import { OperationStatus } from '../../src/operation'
 import { blockchainClientMock } from './mock/blockchainClient.mock'
 import { providerMock } from './mock/provider.mock'
-import { SCEvent } from '../../src'
 
 const OPERATION_ID = 'testOperationID'
 const operation = new Operation(providerMock, OPERATION_ID)
@@ -55,7 +57,7 @@ describe('Operation tests', () => {
         data: 'moreData',
         context: {} as EventExecutionContext,
       },
-    ] as SCEvent[]
+    ] as OutputEvents
 
     jest
       .spyOn(blockchainClientMock, 'getOperationStatus')
@@ -83,7 +85,7 @@ describe('Operation tests', () => {
         data: 'moreData',
         context: {} as EventExecutionContext,
       },
-    ] as SCEvent[]
+    ] as OutputEvents
 
     jest
       .spyOn(blockchainClientMock, 'getOperationStatus')


### PR DESCRIPTION
Changes in OpenRPC documents:
- the type of property `params` of C`allSC` receipt changed from `string` to `number[]` (bytes)
- the typeof property `coins` of `CallSC` receipt changed from `number` to `string` (float number string)
- the typeof property `coins` of `ReadOnlyBytecodeExecution` receipt changed from `number` to `string`
- the typeof property `fee` of `ReadOnlyBytecodeExecution` receipt changed from `number` to `string`
- the typeof property `fee` of `Transfer` receipt receipt changed from `number` to `string`
- the typeof property `amount` of `Transfer `receipt receipt changed from `number` to `string`
- the typeof property `effective_amount_received` of `Transfer` receipt receipt changed from `number` to `string`
