### PR TITLE
refactor(crypto): use @noble/hashes randomBytes instead of secure-random

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
                 "google-protobuf": "^3.21.4",
                 "grpc-web": "^1.5.0",
                 "lodash.isequal": "^4.5.0",
-                "secure-random": "^1.1.2",
                 "tslib": "^2.8.1",
                 "varint": "^6.0.0"
             },
@@ -9695,11 +9694,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/secure-random": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-1.1.2.tgz",
-            "integrity": "sha512-H2bdSKERKdBV1SwoqYm6C0y+9EA94v6SUBOWO8kDndc4NoUih7Dv6Tsgma7zO1lv27wIvjlD0ZpMQk7um5dheQ=="
         },
         "node_modules/semver": {
             "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
         "google-protobuf": "^3.21.4",
         "grpc-web": "^1.5.0",
         "lodash.isequal": "^4.5.0",
-        "secure-random": "^1.1.2",
         "tslib": "^2.8.1",
         "varint": "^6.0.0"
     },

--- a/src/crypto/passwordSeal.ts
+++ b/src/crypto/passwordSeal.ts
@@ -1,5 +1,5 @@
 import Sealer from './interfaces/sealer'
-import randomUint8Array from 'secure-random'
+import { randomBytes } from '@noble/hashes/utils'
 
 import {
   PBKDF2Options,
@@ -31,8 +31,8 @@ export class PasswordSeal implements Sealer {
   public nonce: Uint8Array
 
   constructor(password: string, salt?: Uint8Array, nonce?: Uint8Array) {
-    this.salt = salt ?? randomUint8Array(SALT_SIZE_BYTES)
-    this.nonce = nonce ?? randomUint8Array(NONCE_SIZE_BYTES)
+    this.salt = salt ?? randomBytes(SALT_SIZE_BYTES)
+    this.nonce = nonce ?? randomBytes(NONCE_SIZE_BYTES)
     this.validate()
 
     this.password = password

--- a/test/unit/passwordSeal.spec.ts
+++ b/test/unit/passwordSeal.spec.ts
@@ -1,11 +1,11 @@
 import { PasswordSeal } from '../../src/crypto/passwordSeal'
-import randomUint8Array from 'secure-random'
+import { randomBytes } from '@noble/hashes/utils'
 
 describe('Password Seal tests', () => {
   test('creates Sealer from env variable', async () => {
     process.env.PASSWORD = 'unsecurePassword'
-    process.env.SALT = Buffer.from(randomUint8Array(16)).toString('base64')
-    process.env.NONCE = Buffer.from(randomUint8Array(12)).toString('base64')
+    process.env.SALT = Buffer.from(randomBytes(16)).toString('base64')
+    process.env.NONCE = Buffer.from(randomBytes(12)).toString('base64')
 
     const sealer = PasswordSeal.fromEnv()
     expect(sealer).toBeDefined()


### PR DESCRIPTION
Drop the secure-random dependency for salt/nonce generation in PasswordSeal and use randomBytes from @noble/hashes (already a direct dependency).

Both resolve to the platform CSPRNG (crypto.getRandomValues / OS entropy) and throw when unavailable, so the security guarantee is identical. This removes a lightly-maintained third-party package from the trusted crypto path, shrinking the supply-chain surface.